### PR TITLE
Fix certificate type setter

### DIFF
--- a/src/resources/certificateRequest.js
+++ b/src/resources/certificateRequest.js
@@ -83,7 +83,7 @@ module.exports = class request {
     if (Object.keys(certConfigs).indexOf(certType.toString()) < 0) {
       throw new Error('Invalid or unsupported cert type provided');
     } else {
-      this.#private.certType = certConfigs[Object.keys(certConfigs).indexOf(certType.toString())];
+      this.#private.certType = certType.toString();
     }
   }
 


### PR DESCRIPTION
## Summary
- fix `setCertType` to store the provided certificate type

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./src/resources/certificateRequest')"` *(fails: Cannot find module 'node-forge')*

------
https://chatgpt.com/codex/tasks/task_e_6841769536d48327939af613f500b099