### PR TITLE
Fix boolean return for initialization check

### DIFF
--- a/src/resources/config.js
+++ b/src/resources/config.js
@@ -56,7 +56,7 @@ class Config {
   }
 
   isInitialized() {
-    return this.#private.initialized.toString();
+    return this.#private.initialized;
   }
 
   getServerConfig() {

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -27,7 +27,7 @@ module.exports = () => {
 
   router.route('/')
     .get((req, res) => {
-      if (config.isInitialized()) {
+      if (config.isInitialized() === true) {
         res.send('Ready');
       } else {
         res.send('Awaiting Setup');


### PR DESCRIPTION
## Summary
- return a boolean from `Config.isInitialized`
- compare boolean correctly in `certRouter`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68417cc91e2883279d669eb2bf663b94