### PR TITLE
Handle errors when passphrase invalid

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@ const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-const certRouter = require('./routers/certRouter')();
+const certRouter = require('./routers/certRouter');
 
 app.use('/', certRouter);
 

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -1,17 +1,18 @@
 const express = require('express');
 const controller = require('../controllers/certController');
 const config = require('../resources/config')();
+const logger = require('../utils/logger');
 
 const router = express.Router();
 
 module.exports = () => {
-  router.route('/new')
-    .post((req, res) => {
-      if (!req.body || typeof req.body !== 'object') {
-        return res.status(400).send({
-          error: 'Invalid request body',
-        });
-      }
+    router.route('/new')
+      .post((req, res) => {
+        if (!req.body || typeof req.body !== 'object') {
+          return res.status(400).send({
+            error: 'Invalid request body',
+          });
+        }
       const validator = config.getValidator();
       if (!validator.validateSchema('new', req.body)) {
         return res.status(400).send('Invalid request body');
@@ -21,9 +22,14 @@ module.exports = () => {
         altNames,
         passphrase,
       } = req.body;
-      const newCert = controller.newWebServerCertificate(hostname, passphrase, altNames);
-      return res.send(newCert);
-    });
+      try {
+        const newCert = controller.newWebServerCertificate(hostname, passphrase, altNames);
+        return res.send(newCert);
+      } catch (err) {
+        logger.error(`Error creating certificate: ${err.message}`);
+        return res.status(400).send({ error: 'Unable to process request' });
+      }
+      });
 
   router.route('/')
     .get((req, res) => {

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -5,40 +5,42 @@ const logger = require('../utils/logger');
 
 const router = express.Router();
 
-module.exports = () => {
-    router.route('/new')
-      .post((req, res) => {
-        if (!req.body || typeof req.body !== 'object') {
-          return res.status(400).send({
-            error: 'Invalid request body',
-          });
-        }
-      const validator = config.getValidator();
-      if (!validator.validateSchema('new', req.body)) {
-        return res.status(400).send('Invalid request body');
-      }
-      const {
-        hostname,
-        altNames,
-        passphrase,
-      } = req.body;
-      try {
-        const newCert = controller.newWebServerCertificate(hostname, passphrase, altNames);
-        return res.send(newCert);
-      } catch (err) {
-        logger.error(`Error creating certificate: ${err.message}`);
-        return res.status(400).send({ error: 'Unable to process request' });
-      }
+
+
+router.post('/new', (req, res) => {
+  try {
+    if (!req.body || typeof req.body !== 'object') {
+      logger.error('Invalid request body: must be an object');
+      return res.status(400).send({
+        error: 'Invalid request body',
       });
+    }
+    const validator = config.getValidator();
+    if (!validator.validateSchema('new', req.body)) {
+      logger.error('Invalid request body: schema validation failed');
+      return res.status(400).send({
+        error: 'Invalid request body: schema validation failed',
+      });
+    }
+    const {
+      hostname,
+      altNames,
+      passphrase,
+    } = req.body;
+    
+    const newCert = controller.newWebServerCertificate(hostname, passphrase, altNames);
+    return res.send(newCert);
+  } catch (err) {
+    logger.error(`Error creating certificate: ${err.message}`);
+    return res.status(400).send({ error: 'Unable to process request' });
+  }
+});
 
-  router.route('/')
-    .get((req, res) => {
-      if (config.isInitialized() === true) {
-        res.send('Ready');
-      } else {
-        res.send('Awaiting Setup');
-      }
-    });
+router.get('/', (req, res) => {
+  if (config.isInitialized() === true) {
+    return res.send('Ready');
+  } 
+  return res.send('Awaiting Setup');
+});
 
-  return router;
-};
+module.exports = router;

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -14,14 +14,14 @@ Object.assign(mockConfig, {
   isInitialized: jest.fn(() => true),
 });
 
-const routerFactory = require('../src/routers/certRouter');
+const router = require('../src/routers/certRouter');
 
 describe('certRouter', () => {
   let app;
   beforeEach(() => {
     app = express();
     app.use(express.json());
-    app.use('/', routerFactory());
+    app.use('/', router);
   });
 
   test('root reports readiness', async() => {

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -2,6 +2,8 @@ const request = require('supertest');
 const express = require('express');
 
 const controller = require('../src/controllers/certController');
+jest.mock('../src/utils/logger', () => ({ error: jest.fn(), info: jest.fn(), debug: jest.fn() }));
+const logger = require('../src/utils/logger');
 
 jest.mock('../src/controllers/certController');
 
@@ -39,5 +41,17 @@ describe('certRouter', () => {
       .post('/new')
       .send({ invalid: true });
     expect(invalid.status).toBe(400);
+  });
+
+  test('invalid passphrase handled gracefully', async() => {
+    controller.newWebServerCertificate.mockImplementation(() => {
+      throw new Error('CA Key is locked');
+    });
+    const res = await request(app)
+      .post('/new')
+      .send({ hostname: 'foo.example.com', passphrase: 'bad' });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Unable to process request' });
+    expect(logger.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- handle errors in certificate router by wrapping new cert generation in try/catch
- log errors when certificate generation fails
- return a sanitized error message on failure
- add regression test for invalid passphrase scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844194867188327bd645e1c713bad21