### PR TITLE
Refactor CA to async fs

### DIFF
--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -2,7 +2,7 @@ const CSR = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 
 module.exports = {
-  newWebServerCertificate: async (hostname, passphrase, altNames = false) => {
+  newWebServerCertificate: async(hostname, passphrase, altNames = false) => {
     const csr = new CSR(hostname);
     if (altNames && altNames.length > 0) {
       csr.addAltNames(altNames);

--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -2,7 +2,7 @@ const CSR = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 
 module.exports = {
-  newWebServerCertificate: (hostname, passphrase, altNames = false) => {
+  newWebServerCertificate: async (hostname, passphrase, altNames = false) => {
     const csr = new CSR(hostname);
     if (altNames && altNames.length > 0) {
       csr.addAltNames(altNames);
@@ -13,9 +13,9 @@ module.exports = {
         error: 'Unable to verify CSR',
       };
     }
-    const ca = new CA();
+    const ca = await new CA();
     ca.unlockCA(passphrase);
-    const certificate = ca.signCSR(csr);
+    const certificate = await ca.signCSR(csr);
     const privateKey = csr.getPrivateKey();
     return {
       certificate,

--- a/src/resources/ca.js
+++ b/src/resources/ca.js
@@ -15,7 +15,7 @@ module.exports = class CA {
       root: storeDirectory,
       log: path.join(storeDirectory, 'log.json'),
     };
-    return (async () => {
+    return (async() => {
       this.#private.serial = await fs.readFile(
         path.join(this.#private.store.root, 'serial'),
         'utf-8',

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 
 
-router.post('/new', (req, res) => {
+router.post('/new', async (req, res) => {
   try {
     if (!req.body || typeof req.body !== 'object') {
       logger.error('Invalid request body: must be an object');
@@ -28,7 +28,7 @@ router.post('/new', (req, res) => {
       passphrase,
     } = req.body;
     
-    const newCert = controller.newWebServerCertificate(hostname, passphrase, altNames);
+    const newCert = await controller.newWebServerCertificate(hostname, passphrase, altNames);
     return res.send(newCert);
   } catch (err) {
     logger.error(`Error creating certificate: ${err.message}`);

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 
 
-router.post('/new', async (req, res) => {
+router.post('/new', async(req, res) => {
   try {
     if (!req.body || typeof req.body !== 'object') {
       logger.error('Invalid request body: must be an object');

--- a/tests/ca.test.js
+++ b/tests/ca.test.js
@@ -67,13 +67,13 @@ beforeEach(() => {
 });
 
 describe('CA resource', () => {
-  test('unlockCA calls decrypt', async () => {
+  test('unlockCA calls decrypt', async() => {
     const ca = await new CA();
     ca.unlockCA('pass');
     expect(require('node-forge').pki.decryptRsaPrivateKey).toHaveBeenCalled();
   });
 
-  test('signCSR requires unlocked key', async () => {
+  test('signCSR requires unlocked key', async() => {
     const ca = await new CA();
     const csr = { getCSR: () => 'csr', getHostname: () => 'foo.example.com', getCertType: () => 'webServer', getPrivateKey: () => 'priv' };
     await expect(ca.signCSR(csr)).rejects.toThrow();
@@ -81,7 +81,7 @@ describe('CA resource', () => {
     await expect(ca.signCSR(csr)).resolves.toBe('signedCert');
   });
 
-  test('getSerial increments serial', async () => {
+  test('getSerial increments serial', async() => {
     const ca = await new CA();
     const serial = await ca.getSerial();
     expect(serial).toBe('2');

--- a/tests/ca.test.js
+++ b/tests/ca.test.js
@@ -22,7 +22,28 @@ let CA;
 beforeEach(() => {
   jest.resetModules();
   fs = require('fs');
-  fs.readFileSync.mockImplementation((file) => {
+  fs.promises = {
+    readFile: jest.fn((file) => {
+      if (file.includes('defaults.json')) {
+        return Promise.resolve(JSON.stringify({
+          server: { port: 3000 },
+          storeDirectory: './files',
+          subject: {},
+          validDomains: ['example.com'],
+          extensions: { webServer: [] },
+        }));
+      }
+      if (file.includes('serial')) {
+        return Promise.resolve('1');
+      }
+      if (file.includes('log.json')) {
+        return Promise.resolve(JSON.stringify({ requests: [] }));
+      }
+      return Promise.resolve('dummy');
+    }),
+    writeFile: jest.fn(() => Promise.resolve()),
+  };
+  fs.readFileSync = jest.fn((file) => {
     if (file.includes('defaults.json')) {
       return JSON.stringify({
         server: { port: 3000 },
@@ -40,29 +61,29 @@ beforeEach(() => {
     }
     return 'dummy';
   });
-  fs.writeFileSync.mockImplementation(() => {});
+  fs.writeFileSync = jest.fn(() => {});
   fs.existsSync = jest.fn(() => false);
   CA = require('../src/resources/ca');
 });
 
 describe('CA resource', () => {
-  test('unlockCA calls decrypt', () => {
-    const ca = new CA();
+  test('unlockCA calls decrypt', async () => {
+    const ca = await new CA();
     ca.unlockCA('pass');
     expect(require('node-forge').pki.decryptRsaPrivateKey).toHaveBeenCalled();
   });
 
-  test('signCSR requires unlocked key', () => {
-    const ca = new CA();
+  test('signCSR requires unlocked key', async () => {
+    const ca = await new CA();
     const csr = { getCSR: () => 'csr', getHostname: () => 'foo.example.com', getCertType: () => 'webServer', getPrivateKey: () => 'priv' };
-    expect(() => ca.signCSR(csr)).toThrow();
+    await expect(ca.signCSR(csr)).rejects.toThrow();
     ca.unlockCA('pass');
-    expect(ca.signCSR(csr)).toBe('signedCert');
+    await expect(ca.signCSR(csr)).resolves.toBe('signedCert');
   });
 
-  test('getSerial increments serial', () => {
-    const ca = new CA();
-    const serial = ca.getSerial();
+  test('getSerial increments serial', async () => {
+    const ca = await new CA();
+    const serial = await ca.getSerial();
     expect(serial).toBe('2');
   });
 });

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -23,12 +23,12 @@ describe('certController', () => {
     }));
   });
 
-  test('newWebServerCertificate returns data', async () => {
+  test('newWebServerCertificate returns data', async() => {
     const result = await controller.newWebServerCertificate('foo.example.com', 'pass');
     expect(result).toEqual({ certificate: 'cert', privateKey: 'priv', hostname: 'foo.example.com' });
   });
 
-  test('alt names passed to request', async () => {
+  test('alt names passed to request', async() => {
     await controller.newWebServerCertificate('foo.example.com', 'pass', ['alt.example.com']);
     expect(CSR).toHaveBeenCalledWith('foo.example.com');
     expect(CSR.mock.results[0].value.addAltNames).toHaveBeenCalledWith(['alt.example.com']);

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -23,13 +23,13 @@ describe('certController', () => {
     }));
   });
 
-  test('newWebServerCertificate returns data', () => {
-    const result = controller.newWebServerCertificate('foo.example.com', 'pass');
+  test('newWebServerCertificate returns data', async () => {
+    const result = await controller.newWebServerCertificate('foo.example.com', 'pass');
     expect(result).toEqual({ certificate: 'cert', privateKey: 'priv', hostname: 'foo.example.com' });
   });
 
-  test('alt names passed to request', () => {
-    controller.newWebServerCertificate('foo.example.com', 'pass', ['alt.example.com']);
+  test('alt names passed to request', async () => {
+    await controller.newWebServerCertificate('foo.example.com', 'pass', ['alt.example.com']);
     expect(CSR).toHaveBeenCalledWith('foo.example.com');
     expect(CSR.mock.results[0].value.addAltNames).toHaveBeenCalledWith(['alt.example.com']);
   });

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -30,7 +30,7 @@ describe('certRouter', () => {
   });
 
   test('post /new validates body', async() => {
-    controller.newWebServerCertificate.mockReturnValue({ ok: true });
+    controller.newWebServerCertificate.mockResolvedValue({ ok: true });
     const res = await request(app).post('/new').send({ hostname: 'foo.example.com', passphrase: 'p' });
     expect(res.body).toEqual({ ok: true });
   });


### PR DESCRIPTION
## Summary
- swap fs sync operations for `fs.promises` in CA
- update CA API and callers to async/await
- adjust tests for async CA behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846119d6aa4832792a892708e32ceb3