### PR TITLE
Rename request class

### DIFF
--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -1,9 +1,9 @@
-const CSR = require('../resources/certificateRequest');
+const CertificateRequest = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 
 module.exports = {
   newWebServerCertificate: async(hostname, passphrase, altNames = false) => {
-    const csr = new CSR(hostname);
+    const csr = new CertificateRequest(hostname);
     if (altNames && altNames.length > 0) {
       csr.addAltNames(altNames);
     }

--- a/src/resources/certificateRequest.js
+++ b/src/resources/certificateRequest.js
@@ -3,7 +3,7 @@ const net = require('net');
 const forge = require('node-forge');
 const config = require('./config')();
 
-module.exports = class request {
+module.exports = class CertificateRequest {
   #private = {};
 
   constructor(hostname) {

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -1,15 +1,15 @@
 jest.mock('../src/resources/certificateRequest');
 jest.mock('../src/resources/ca');
 
-const CSR = require('../src/resources/certificateRequest');
+const CertificateRequest = require('../src/resources/certificateRequest');
 const CA = require('../src/resources/ca');
 const controller = require('../src/controllers/certController');
 
 describe('certController', () => {
   beforeEach(() => {
-    CSR.mockClear();
+    CertificateRequest.mockClear();
     CA.mockClear();
-    CSR.mockImplementation(() => ({
+    CertificateRequest.mockImplementation(() => ({
       addAltNames: jest.fn(),
       sign: jest.fn(),
       verify: jest.fn(() => true),
@@ -30,7 +30,7 @@ describe('certController', () => {
 
   test('alt names passed to request', async() => {
     await controller.newWebServerCertificate('foo.example.com', 'pass', ['alt.example.com']);
-    expect(CSR).toHaveBeenCalledWith('foo.example.com');
-    expect(CSR.mock.results[0].value.addAltNames).toHaveBeenCalledWith(['alt.example.com']);
+    expect(CertificateRequest).toHaveBeenCalledWith('foo.example.com');
+    expect(CertificateRequest.mock.results[0].value.addAltNames).toHaveBeenCalledWith(['alt.example.com']);
   });
 });

--- a/tests/certificateRequest.test.js
+++ b/tests/certificateRequest.test.js
@@ -19,40 +19,40 @@ jest.mock('node-forge', () => {
   };
 });
 
-const Request = require('../src/resources/certificateRequest');
+const CertificateRequest = require('../src/resources/certificateRequest');
 
 describe('certificateRequest', () => {
   test('hostname stored lowercase', () => {
-    const req = new Request('Foo.EXAMPLE.com');
+    const req = new CertificateRequest('Foo.EXAMPLE.com');
     expect(req.getHostname()).toBe('foo.example.com');
   });
 
   test('constructor rejects invalid hostname', () => {
-    expect(() => new Request('badhost')).toThrow('Invalid hostname');
+    expect(() => new CertificateRequest('badhost')).toThrow('Invalid hostname');
   });
 
   test('sign generates csr', () => {
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     req.sign();
     expect(req.getCSR()).toBe('csrPem');
   });
 
   test('verify proxies to csr', () => {
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     req.sign();
     expect(req.verify()).toBe(true);
     expect(require('node-forge').__mockCsr.verify).toHaveBeenCalled();
   });
 
   test('setCertType validates input', () => {
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     expect(() => req.setCertType('invalid')).toThrow();
     req.setCertType('webServer');
     expect(req.getCertType()).toBe('webServer');
   });
 
   test('addAltNames adds SAN extension', () => {
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     req.addAltNames(['bar.example.com']);
     req.sign();
     expect(require('node-forge').__mockCsr.setAttributes).toHaveBeenCalled();
@@ -61,7 +61,7 @@ describe('certificateRequest', () => {
   test('invalid SAN entries are ignored', () => {
     const forge = require('node-forge');
     forge.__mockCsr.setAttributes.mockClear();
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     req.addAltNames(['bar.bad.com', 'BAR.EXAMPLE.COM', 'foo.com']);
     req.sign();
     const attrs = forge.__mockCsr.setAttributes.mock.calls[0][0];
@@ -74,7 +74,7 @@ describe('certificateRequest', () => {
   test('ip SAN entries are allowed', () => {
     const forge = require('node-forge');
     forge.__mockCsr.setAttributes.mockClear();
-    const req = new Request('foo.example.com');
+    const req = new CertificateRequest('foo.example.com');
     req.addAltNames(['192.168.0.1', 'BAR.EXAMPLE.COM', '10.0.0.1']);
     req.sign();
     const attrs = forge.__mockCsr.setAttributes.mock.calls[0][0];


### PR DESCRIPTION
## Summary
- rename request class to `CertificateRequest`
- update requires for new name in controller and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d7ad4bd48327b06c977e7fe3feb2