### PR TITLE
Add JSDoc across codebase

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,6 @@
+/**
+ * Entry point for the certificate manager HTTP server.
+ */
 const app = require('./src/app');
 const config = require('./src/resources/config')();
 const logger = require('./src/utils/logger');

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 
+/**
+ * Express application instance.
+ */
 const app = express();
 
 app.use(bodyParser.urlencoded({ extended: false }));
@@ -10,4 +13,9 @@ const certRouter = require('./routers/certRouter');
 
 app.use('/', certRouter);
 
+/**
+ * Export the configured Express application for server startup and testing.
+ *
+ * @type {import('express').Application}
+ */
 module.exports = app;

--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -2,6 +2,14 @@ const CertificateRequest = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 
 module.exports = {
+  /**
+   * Generate and sign a new web server certificate.
+   *
+   * @param {string} hostname - Fully qualified domain name for the certificate.
+   * @param {string} passphrase - Passphrase to unlock the CA key.
+   * @param {string[]|false} [altNames=false] - Optional alternative names.
+   * @returns {Promise<Object>} Resolves with certificate and key PEM strings.
+   */
   newWebServerCertificate: async(hostname, passphrase, altNames = false) => {
     const csr = new CertificateRequest(hostname);
     if (altNames && altNames.length > 0) {

--- a/src/resources/config.js
+++ b/src/resources/config.js
@@ -11,9 +11,18 @@ const configurationFiles = {
 let config = false;
 
 // TODO: Move CA methods to their own class.
+/**
+ * Configuration management and validation helper.
+ */
+/**
+ * Configuration management and validation helper.
+ */
 class Config {
   #private = {};
 
+  /**
+   * Initialize configuration from defaults and check file system state.
+   */
   constructor() {
     this.#private.configuration = JSON.parse(
       fs.readFileSync(configurationFiles.default, 'utf8'),
@@ -44,32 +53,67 @@ class Config {
     }
   }
 
+  /**
+   * Retrieve a copy of the default certificate subject attributes.
+   *
+   * @returns {Object[]} Array of subject attribute objects.
+   */
   getSubject() {
     return JSON.parse(JSON.stringify(this.#private.subjectDefaults));
   }
 
+  /**
+   * Get the absolute path of the certificate store directory.
+   *
+   * @returns {string} Directory path used to persist certificates.
+   */
   getStoreDirectory() {
     return this.#private.storeDirectory;
   }
 
+  /**
+   * Create a new Validator instance using the loaded configuration.
+   *
+   * @returns {import('./validator')} Validator for input checking.
+   */
   getValidator() {
     return new Validator(this.#private.configuration);
   }
 
+  /**
+   * Determine if the certificate store appears to be initialized.
+   *
+   * @returns {boolean} True when required CA files exist.
+   */
   isInitialized() {
     return this.#private.initialized;
   }
 
+  /**
+   * Provide server configuration settings from the defaults file.
+   *
+   * @returns {Object} Configuration for the web server.
+   */
   getServerConfig() {
     return JSON.parse(JSON.stringify(this.#private.configuration.server));
   }
 
+  /**
+   * Retrieve configured X.509 extension profiles.
+   *
+   * @returns {Object.<string,Array>} Mapping of extension sets by name.
+   */
   getCertExtensions() {
     return JSON.parse(JSON.stringify(this.#private.configuration.extensions));
   }
 
 }
 
+/**
+ * Singleton factory for the Config instance.
+ *
+ * @returns {Config} Configured instance reused across imports.
+ */
 module.exports = () => {
   if (!config) {
     config = new Config();

--- a/src/resources/validator.js
+++ b/src/resources/validator.js
@@ -1,15 +1,30 @@
 const jsonSchema = require('jsonschema');
 const schemas = require('./schemas');
 
+/**
+ * Simple validation wrapper providing hostname and schema checks.
+ */
 module.exports = class Validator {
   #private = {};
 
+  /**
+   * Create a new Validator.
+   *
+   * @param {Object} configuration - Parsed configuration object.
+   */
   constructor(configuration) {
     this.#private.config = configuration;
     this.#private.Validator = jsonSchema.Validator;
     this.#private.schemas = schemas;
   }
 
+  /**
+   * Validate that a hostname belongs to an allowed domain and has
+   * at least three labels.
+   *
+   * @param {string} hostname - Hostname to verify.
+   * @returns {boolean} True for valid hostnames.
+   */
   hostname(hostname) {
     if (hostname.indexOf('.') < 0) {
       return false;
@@ -26,6 +41,13 @@ module.exports = class Validator {
     return true;
   }
 
+  /**
+   * Validate a data object against one of the configured JSON schemas.
+   *
+   * @param {string} schemaName - Name of the schema to use.
+   * @param {Object} data - Data object to validate.
+   * @returns {boolean} True when data conforms to the schema.
+   */
   validateSchema(schemaName, data) {
     const validator = new this.#private.Validator();
     const validationResults = validator.validate(data, this.#private.schemas[schemaName]);

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -3,6 +3,9 @@ const controller = require('../controllers/certController');
 const config = require('../resources/config')();
 const logger = require('../utils/logger');
 
+/**
+ * Express router exposing certificate issuance endpoints.
+ */
 const router = express.Router();
 
 
@@ -43,4 +46,9 @@ router.get('/', (req, res) => {
   return res.send('Awaiting Setup');
 });
 
+/**
+ * Export the configured router for mounting in an Express app.
+ *
+ * @type {import('express').Router}
+ */
 module.exports = router;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,5 +1,10 @@
 const { createLogger, format, transports } = require('winston');
 
+/**
+ * Application-wide Winston logger instance.
+ * @module logger
+ */
+
 const loggerTransports = [
   new transports.Console({
     format: format.combine(
@@ -20,4 +25,9 @@ const logger = createLogger({
   transports: loggerTransports,
 });
 
+/**
+ * Shared logger instance.
+ *
+ * @type {import('winston').Logger}
+ */
 module.exports = logger;


### PR DESCRIPTION
## Summary
- document CA helpers and certificate request public methods
- add comprehensive JSDoc for config, validator, controller, router and utils
- annotate Express app and server entry point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846ec2fdb1c83278576a6343223c37a