### PR TITLE
Improve error context for CSR handling

### DIFF
--- a/src/resources/ca.js
+++ b/src/resources/ca.js
@@ -74,13 +74,13 @@ module.exports = class CA {
    */
   async signCSR(CSR) {
     if (!this.#private.caKey) {
-      throw new Error('CA Key is locked');
+      throw new Error(`CA key is locked; unable to sign certificate for ${CSR.getHostname()}`);
     }
     const csr = forge.pki.certificationRequestFromPem(CSR.getCSR());
     const caCert = forge.pki.certificateFromPem(this.#private.caCert);
     const { caKey } = this.#private;
     if (!csr.verify()) {
-      throw new Error('Invalid CSR');
+      throw new Error(`CSR verification failed for ${CSR.getHostname()}`);
     }
     const newCert = forge.pki.createCertificate();
     newCert.serialNumber = await this.getSerial();

--- a/src/resources/certificateRequest.js
+++ b/src/resources/certificateRequest.js
@@ -27,7 +27,7 @@ module.exports = class CertificateRequest {
     this.#private.validator = config.getValidator();
     const normalized = hostname.toString().toLowerCase();
     if (!this.#private.validator.hostname(normalized)) {
-      throw new Error('Invalid hostname');
+      throw new Error(`Invalid hostname: ${hostname}`);
     }
     subject.push({
       shortName: 'CN',
@@ -140,7 +140,7 @@ module.exports = class CertificateRequest {
   setCertType(certType) {
     const certConfigs = config.getCertExtensions();
     if (Object.keys(certConfigs).indexOf(certType.toString()) < 0) {
-      throw new Error('Invalid or unsupported cert type provided');
+      throw new Error(`Unsupported certificate type '${certType}'. Supported types: ${Object.keys(certConfigs).join(', ')}`);
     } else {
       this.#private.certType = certType.toString();
     }

--- a/tests/certificateRequest.test.js
+++ b/tests/certificateRequest.test.js
@@ -28,7 +28,7 @@ describe('certificateRequest', () => {
   });
 
   test('constructor rejects invalid hostname', () => {
-    expect(() => new CertificateRequest('badhost')).toThrow('Invalid hostname');
+    expect(() => new CertificateRequest('badhost')).toThrow('Invalid hostname: badhost');
   });
 
   test('sign generates csr', () => {


### PR DESCRIPTION
## Summary
- add hostname context when CSR validation fails or CA key is locked
- include invalid values in certificate request errors
- adjust tests for new messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f2533f0883278df1ee89cbe31485