### PR TITLE
Add dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "setup": "npm install --production && node scripts/setup.js",
     "win": "nodemon server.js",
+    "dev": "nodemon server.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest --coverage"

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,10 @@ SET CAPASS=SecretPassphrase && npm run setup
 ```
 4. Run the server
 ```cmd
+npm run dev
+```
+Windows users can instead run the following command:
+```cmd
 npm run win
 ```
 5. Submit a post request to the http://localhost:`port`/new endpoint with the following json body
@@ -72,4 +76,4 @@ npm run win
 - Allow for creating intermediate CAs
 - Allow more customization regarding certificate types and subjects
 - Alert administrator when certificate is about to expire
-- Enable admins to auto issue new certificates and send to certificate administrator
+- Enable admins to auto issue new certificates and send them to the certificate administrator


### PR DESCRIPTION
## Summary
- add a `dev` script for running the server with nodemon
- document `npm run dev` usage in the README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f428ea388327a82c3a600dfa3dfa