### PR TITLE
Fix CA extension typo

### DIFF
--- a/config/defaults.example.json
+++ b/config/defaults.example.json
@@ -36,7 +36,7 @@
   "extensions": {
     "CA": [
       {
-        "name": "basicContraints",
+        "name": "basicConstraints",
         "cA": true
       },
       {


### PR DESCRIPTION
## Summary
- fix spelling of `basicConstraints` in default CA extension config

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847080a20e88327be01dd5b8e92d1f9