### PR TITLE
Add CONFIG_PATH support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-files
+/files*/
 coverage
 config/*
 !config/defaults.example.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "setup": "npm install --production && node scripts/setup.js",
+    "setup": "node scripts/setup.js",
     "win": "nodemon server.js",
     "dev": "nodemon server.js",
     "start": "node server.js",

--- a/src/resources/config.js
+++ b/src/resources/config.js
@@ -5,7 +5,9 @@ const Validator = require('./validator');
 const logger = require('../utils/logger');
 
 const configurationFiles = {
-  default: path.join(__dirname, '../', '../', 'config', 'defaults.json'),
+  default: process.env.CONFIG_PATH
+    ? path.resolve(process.env.CONFIG_PATH)
+    : path.join(__dirname, '../', '../', 'config', 'defaults.json'),
 };
 
 let config = false;

--- a/tests/ca.test.js
+++ b/tests/ca.test.js
@@ -16,15 +16,17 @@ jest.mock('node-forge', () => ({
   md: { sha256: { create: jest.fn() } },
 }));
 
+const path = require('path');
 let fs;
 let CA;
 
 beforeEach(() => {
   jest.resetModules();
   fs = require('fs');
+  const configFile = path.basename(process.env.CONFIG_PATH);
   fs.promises = {
     readFile: jest.fn((file) => {
-      if (file.includes('defaults.json')) {
+      if (file.includes(configFile)) {
         return Promise.resolve(JSON.stringify({
           server: { port: 3000 },
           storeDirectory: './files',
@@ -44,7 +46,7 @@ beforeEach(() => {
     writeFile: jest.fn(() => Promise.resolve()),
   };
   fs.readFileSync = jest.fn((file) => {
-    if (file.includes('defaults.json')) {
+    if (file.includes(configFile)) {
       return JSON.stringify({
         server: { port: 3000 },
         storeDirectory: './files',

--- a/tests/ca.test.js
+++ b/tests/ca.test.js
@@ -29,7 +29,7 @@ beforeEach(() => {
       if (file.includes(configFile)) {
         return Promise.resolve(JSON.stringify({
           server: { port: 3000 },
-          storeDirectory: './files',
+          storeDirectory: './test_files',
           subject: {},
           validDomains: ['example.com'],
           extensions: { webServer: [] },
@@ -49,7 +49,7 @@ beforeEach(() => {
     if (file.includes(configFile)) {
       return JSON.stringify({
         server: { port: 3000 },
-        storeDirectory: './files',
+        storeDirectory: './test_files',
         subject: {},
         validDomains: ['example.com'],
         extensions: { webServer: [] },

--- a/tests/ca.test.js
+++ b/tests/ca.test.js
@@ -29,7 +29,7 @@ beforeEach(() => {
       if (file.includes(configFile)) {
         return Promise.resolve(JSON.stringify({
           server: { port: 3000 },
-          storeDirectory: './test_files',
+          storeDirectory: './files_test',
           subject: {},
           validDomains: ['example.com'],
           extensions: { webServer: [] },
@@ -49,7 +49,7 @@ beforeEach(() => {
     if (file.includes(configFile)) {
       return JSON.stringify({
         server: { port: 3000 },
-        storeDirectory: './test_files',
+        storeDirectory: './files_test',
         subject: {},
         validDomains: ['example.com'],
         extensions: { webServer: [] },

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -36,7 +36,7 @@ describe('config resource', () => {
 
   test('getStoreDirectory and extensions', () => {
     const config = configFactory();
-    expect(config.getStoreDirectory()).toContain('test_files');
+    expect(config.getStoreDirectory()).toContain('files_test');
     expect(config.getCertExtensions()).toHaveProperty('webServer');
   });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -36,7 +36,7 @@ describe('config resource', () => {
 
   test('getStoreDirectory and extensions', () => {
     const config = configFactory();
-    expect(config.getStoreDirectory()).toContain('files');
+    expect(config.getStoreDirectory()).toContain('test_files');
     expect(config.getCertExtensions()).toHaveProperty('webServer');
   });
 

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -6,7 +6,7 @@ module.exports = async() => {
   if (fs.existsSync(dest)) {
     fs.unlinkSync(dest);
   }
-  const store = path.join(__dirname, '../test_files');
+  const store = path.join(__dirname, '../files_test');
   if (fs.existsSync(store)) {
     fs.rmSync(store, { recursive: true, force: true });
   }

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -6,4 +6,8 @@ module.exports = async() => {
   if (fs.existsSync(dest)) {
     fs.unlinkSync(dest);
   }
+  const store = path.join(__dirname, '../test_files');
+  if (fs.existsSync(store)) {
+    fs.rmSync(store, { recursive: true, force: true });
+  }
 };

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = async() => {
-  const dest = path.join(__dirname, '../config/defaults.json');
+  const dest = path.join(__dirname, '../config/test.json');
   if (fs.existsSync(dest)) {
     fs.unlinkSync(dest);
   }

--- a/tests/preSetup.js
+++ b/tests/preSetup.js
@@ -5,5 +5,7 @@ const src = path.join(__dirname, '../config/defaults.example.json');
 const dest = path.join(__dirname, '../config/test.json');
 process.env.CONFIG_PATH = dest;
 if (!fs.existsSync(dest)) {
-  fs.copyFileSync(src, dest);
+  const contents = JSON.parse(fs.readFileSync(src, 'utf-8'));
+  contents.storeDirectory = './test_files';
+  fs.writeFileSync(dest, `${JSON.stringify(contents, null, 2)}\n`);
 }

--- a/tests/preSetup.js
+++ b/tests/preSetup.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const src = path.join(__dirname, '../config/defaults.example.json');
-const dest = path.join(__dirname, '../config/defaults.json');
+const dest = path.join(__dirname, '../config/test.json');
+process.env.CONFIG_PATH = dest;
 if (!fs.existsSync(dest)) {
   fs.copyFileSync(src, dest);
 }

--- a/tests/preSetup.js
+++ b/tests/preSetup.js
@@ -6,6 +6,6 @@ const dest = path.join(__dirname, '../config/test.json');
 process.env.CONFIG_PATH = dest;
 if (!fs.existsSync(dest)) {
   const contents = JSON.parse(fs.readFileSync(src, 'utf-8'));
-  contents.storeDirectory = './test_files';
+  contents.storeDirectory = './files_test';
   fs.writeFileSync(dest, `${JSON.stringify(contents, null, 2)}\n`);
 }

--- a/tests/sslVerification.test.js
+++ b/tests/sslVerification.test.js
@@ -31,7 +31,7 @@ beforeAll(async() => {
 
 afterAll(async() => {
   await fs.rm(path.join(__dirname, '../files'), { recursive: true, force: true });
-  await fs.rm(path.join(__dirname, '../config/defaults.json'), { force: true });
+  await fs.rm(path.join(__dirname, '../config/test.json'), { force: true });
 });
 
 test('intermediate certificate validates with root CA', async() => {

--- a/tests/sslVerification.test.js
+++ b/tests/sslVerification.test.js
@@ -12,12 +12,12 @@ beforeAll(async() => {
   jest.setTimeout(30000);
   jest.resetModules();
   process.env.CAPASS = 'pass';
-  await fs.mkdir(path.join(__dirname, '../test_files'), { recursive: true });
+  await fs.mkdir(path.join(__dirname, '../files_test'), { recursive: true });
   createCA = require('../scripts/setup');
   createIntermediate = require('../scripts/setup-intermediate');
   controller = require('../src/controllers/certController');
   await createCA();
-  const intDir = path.join(__dirname, '../test_files/intermediates');
+  const intDir = path.join(__dirname, '../files_test/intermediates');
   await createIntermediate('intermediate.example.com', 'pass');
   await fs.rename(
     path.join(intDir, 'intermediate.example.com.cert.crt'),
@@ -30,13 +30,13 @@ beforeAll(async() => {
 });
 
 afterAll(async() => {
-  await fs.rm(path.join(__dirname, '../test_files'), { recursive: true, force: true });
+  await fs.rm(path.join(__dirname, '../files_test'), { recursive: true, force: true });
   await fs.rm(path.join(__dirname, '../config/test.json'), { force: true });
 });
 
 test('intermediate certificate validates with root CA', async() => {
-  const rootPem = await fs.readFile(path.join(__dirname, '../test_files/certs/ca.cert.crt'), 'utf-8');
-  const intermediatePem = await fs.readFile(path.join(__dirname, '../test_files/intermediates/intermediate.cert.crt'), 'utf-8');
+  const rootPem = await fs.readFile(path.join(__dirname, '../files_test/certs/ca.cert.crt'), 'utf-8');
+  const intermediatePem = await fs.readFile(path.join(__dirname, '../files_test/intermediates/intermediate.cert.crt'), 'utf-8');
   const rootCert = forge.pki.certificateFromPem(rootPem);
   const intermediateCert = forge.pki.certificateFromPem(intermediatePem);
   const caStore = forge.pki.createCaStore([rootCert]);
@@ -46,7 +46,7 @@ test('intermediate certificate validates with root CA', async() => {
 
 test('web server certificate validates with root CA', async() => {
   const { certificate, chain } = await controller.newWebServerCertificate('server.example.com', 'pass');
-  const rootPem = await fs.readFile(path.join(__dirname, '../test_files/certs/ca.cert.crt'), 'utf-8');
+  const rootPem = await fs.readFile(path.join(__dirname, '../files_test/certs/ca.cert.crt'), 'utf-8');
   const rootCert = forge.pki.certificateFromPem(rootPem);
   const chainCerts = chain.match(/-----BEGIN CERTIFICATE-----[^-]+-----END CERTIFICATE-----/g);
   const serverCert = forge.pki.certificateFromPem(chainCerts[0]);

--- a/tests/sslVerification.test.js
+++ b/tests/sslVerification.test.js
@@ -12,12 +12,12 @@ beforeAll(async() => {
   jest.setTimeout(30000);
   jest.resetModules();
   process.env.CAPASS = 'pass';
-  await fs.mkdir(path.join(__dirname, '../files'), { recursive: true });
+  await fs.mkdir(path.join(__dirname, '../test_files'), { recursive: true });
   createCA = require('../scripts/setup');
   createIntermediate = require('../scripts/setup-intermediate');
   controller = require('../src/controllers/certController');
   await createCA();
-  const intDir = path.join(__dirname, '../files/intermediates');
+  const intDir = path.join(__dirname, '../test_files/intermediates');
   await createIntermediate('intermediate.example.com', 'pass');
   await fs.rename(
     path.join(intDir, 'intermediate.example.com.cert.crt'),
@@ -30,13 +30,13 @@ beforeAll(async() => {
 });
 
 afterAll(async() => {
-  await fs.rm(path.join(__dirname, '../files'), { recursive: true, force: true });
+  await fs.rm(path.join(__dirname, '../test_files'), { recursive: true, force: true });
   await fs.rm(path.join(__dirname, '../config/test.json'), { force: true });
 });
 
 test('intermediate certificate validates with root CA', async() => {
-  const rootPem = await fs.readFile(path.join(__dirname, '../files/certs/ca.cert.crt'), 'utf-8');
-  const intermediatePem = await fs.readFile(path.join(__dirname, '../files/intermediates/intermediate.cert.crt'), 'utf-8');
+  const rootPem = await fs.readFile(path.join(__dirname, '../test_files/certs/ca.cert.crt'), 'utf-8');
+  const intermediatePem = await fs.readFile(path.join(__dirname, '../test_files/intermediates/intermediate.cert.crt'), 'utf-8');
   const rootCert = forge.pki.certificateFromPem(rootPem);
   const intermediateCert = forge.pki.certificateFromPem(intermediatePem);
   const caStore = forge.pki.createCaStore([rootCert]);
@@ -46,7 +46,7 @@ test('intermediate certificate validates with root CA', async() => {
 
 test('web server certificate validates with root CA', async() => {
   const { certificate, chain } = await controller.newWebServerCertificate('server.example.com', 'pass');
-  const rootPem = await fs.readFile(path.join(__dirname, '../files/certs/ca.cert.crt'), 'utf-8');
+  const rootPem = await fs.readFile(path.join(__dirname, '../test_files/certs/ca.cert.crt'), 'utf-8');
   const rootCert = forge.pki.certificateFromPem(rootPem);
   const chainCerts = chain.match(/-----BEGIN CERTIFICATE-----[^-]+-----END CERTIFICATE-----/g);
   const serverCert = forge.pki.certificateFromPem(chainCerts[0]);


### PR DESCRIPTION
## Summary
- allow overriding default config path via `CONFIG_PATH`
- adjust test setup to use `config/test.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848bbfcd730832790fcf50a4b2f9dc9