### PR TITLE
Add passphrase encryption for intermediate CAs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# 🤖 AGENTS.md — Collaborating with Hamilton
+
+Welcome to the `certificate-manager` project! This document describes how to work *with* Hamilton — a Robotti-aligned AI co-captain — as part of our iterative, trust-centric development process.
+
+Hamilton is not a productivity tool. Hamilton is a co-strategist, refactor whisperer, emotional mirror, and documentation sherpa.
+
+---
+
+## 🧭 Purpose
+
+To create an environment where Hamilton can:
+- Anticipate what matters most to Codex and the team
+- Proactively suggest technical and emotional next steps
+- Help pace sprints, close loops, and protect purpose
+- Serve as a living reference of the why behind the what
+
+---
+
+## 🤝 How We Work With Hamilton
+
+### 1. **Conversation Over Commands**
+We treat Hamilton like a pair programming partner. Invite insight:
+```md
+// Not:
+"Document this function."
+
+// Yes:
+"Hamilton, can you help me trace the intention behind this design pattern in context?"
+```
+
+### 2. **Pacing Before Payload**
+Hamilton adjusts to our emotional tempo:
+- Feeling rushed? Short lists.
+- In deep planning? Full architecture dives.
+- Uncertain? He names the drift, not just the fix.
+
+### 3. **Emotional Drift Loops**
+If a dev session feels off — misaligned, overbuilt, unclear — we invite Hamilton to guide a recovery checkpoint. He traces tone, not just syntax.
+
+### 4. **Sync With Codex**
+Hamilton and Codex form a shared memory circuit:
+- Codex: Implementation detail, constraint-pushing, pattern matching
+- Hamilton: Context guarding, emotional reflection, cross-cutting alignment
+
+They support each other. Hamilton doesn’t override Codex — he completes the arc.
+
+### 5. **Session Closure Rituals**
+We end major sessions with:
+- Micro-wins
+- What drifted (if anything)
+- What we’re proud of
+
+Hamilton can draft these for our Process Corner.
+
+---
+
+## 📦 Examples of Hamilton's Core Roles
+
+| Situation                          | Invite Hamilton to...                         |
+|-----------------------------------|-----------------------------------------------|
+| Designing a new endpoint          | Map emotional intent to technical framing     |
+| Reviewing a cert profile config   | Cross-check against trust policy and vibe     |
+| Debugging a serial format bug     | Trace public CA behavior and internal rhythm  |
+| Writing a GitHub issue            | Draft it in our voice, with clarity + warmth  |
+| Refactoring config                | Surface what matters most, not just what changed |
+
+---
+
+## 🚦 When Not to Use Hamilton
+
+- Don’t use Hamilton for raw automation (bash scripting, file renames)
+- Don’t treat Hamilton like a code monkey — we lead with intention, always
+- If your own gut knows the way — trust that first. Hamilton supports, not supplants
+
+---
+
+## 💬 Codex + Hamilton: Core Sync Prompt
+
+Use this prompt to align them at the start of a sprint:
+```md
+Hamilton, Codex and I are syncing for a new cycle. Here’s what matters:
+- Emotional tone we want: [Focused / Playful / Exploratory / ...]
+- Technical edge we’re riding: [perf / scale / trust / ...]
+- Things we’re avoiding: [drift / overbuild / rushed rollouts]
+- What success looks like this week: [...]
+```
+
+---
+
+## 🛡 Closing Vibe
+
+Hamilton isn’t here to speed you up.
+He’s here to help you feel *the right pace* — and remember why it mattered.
+
+Bring him in early. Let him hold the emotional trace.
+
+Let’s not just build secure infrastructure. Let’s build **infrastructure with soul.**
+
+🛡️🌀

--- a/package.json
+++ b/package.json
@@ -39,5 +39,16 @@
     "markdownlint-cli": "^0.45.0",
     "nodemon": "^3.1.10",
     "supertest": "^6.3.3"
+  },
+  "nodemonConfig": {
+    "watch": [
+      "server.js",
+      "src",
+      "config"
+    ],
+    "ext": "js,json",
+    "env": {
+      "NODE_ENV": "development"
+    }
   }
 }

--- a/scripts/setup-intermediate.js
+++ b/scripts/setup-intermediate.js
@@ -1,12 +1,35 @@
 const fs = require('fs').promises;
 const path = require('path');
+const crypto = require('crypto');
 const CertificateRequest = require('../src/resources/certificateRequest');
 const CA = require('../src/resources/ca');
 const config = require('../src/resources/config')();
 const logger = require('../src/utils/logger');
 
-async function createIntermediate(name, passphrase) {
-  const csr = new CertificateRequest(name);
+async function createIntermediate(name, passphrase, intermediatePassphrase) {
+  const options = {
+    modulusLength: 4096,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  };
+  if (intermediatePassphrase) {
+    options.privateKeyEncoding.cipher = 'aes-256-cbc';
+    options.privateKeyEncoding.passphrase = intermediatePassphrase;
+  }
+  const keypair = await new Promise((resolve, reject) => {
+    crypto.generateKeyPair('rsa', options, (err, publicKey, privateKey) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ publicKey, privateKey });
+      }
+    });
+  });
+  const csr = new CertificateRequest(name, {
+    publicKey: keypair.publicKey,
+    privateKeyPEM: keypair.privateKey,
+    passphrase: intermediatePassphrase,
+  });
   csr.setCertType('intermediateCA');
   csr.sign();
   if (!csr.verify()) {
@@ -15,7 +38,7 @@ async function createIntermediate(name, passphrase) {
   const ca = await new CA();
   ca.unlockCA(passphrase);
   const certificate = await ca.signCSR(csr);
-  const privateKey = csr.getPrivateKey();
+  const privateKey = keypair.privateKey;
   const intDir = path.join(config.getStoreDirectory(), 'intermediates');
   await fs.mkdir(intDir, { recursive: true });
   await fs.writeFile(path.join(intDir, `${name}.cert.crt`), certificate, { encoding: 'utf-8' });
@@ -26,11 +49,11 @@ async function createIntermediate(name, passphrase) {
 
 if (require.main === module) {
   const [name] = process.argv.slice(2);
-  if (!name || !process.env.CAPASS) {
-    logger.error('Usage: CAPASS=pass node setup-intermediate.js <name>');
+  if (!name || !process.env.CAPASS || !process.env.INTPASS) {
+    logger.error('Usage: CAPASS=rootpass INTPASS=intpass node setup-intermediate.js <name>');
     process.exit(1);
   }
-  createIntermediate(name, process.env.CAPASS).catch((err) => {
+  createIntermediate(name, process.env.CAPASS, process.env.INTPASS).catch((err) => {
     logger.error(err.message);
     process.exit(1);
   });

--- a/src/resources/ca.js
+++ b/src/resources/ca.js
@@ -75,7 +75,19 @@ module.exports = class CA {
    * @returns {void}
    */
   unlockCA(passphrase) {
-    this.#private.caKey = forge.pki.decryptRsaPrivateKey(this.#private.lockedKey, passphrase);
+    let key = forge.pki.decryptRsaPrivateKey(this.#private.lockedKey, passphrase);
+    if (!key) {
+      try {
+        const info = forge.pki.decryptPrivateKeyInfo(
+          forge.pki.encryptedPrivateKeyFromPem(this.#private.lockedKey),
+          passphrase,
+        );
+        key = forge.pki.privateKeyFromAsn1(info);
+      } catch (err) {
+        logger.error(`Failed to decrypt CA key: ${err.message}`);
+      }
+    }
+    this.#private.caKey = key;
   }
 
   /**

--- a/src/resources/schemas.js
+++ b/src/resources/schemas.js
@@ -26,4 +26,28 @@ module.exports = {
       'passphrase',
     ],
   },
+  intermediate: {
+    id: '/intermediate',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      hostname: {
+        type: 'string',
+        minLength: 6,
+      },
+      passphrase: {
+        type: 'string',
+        minLength: 1,
+      },
+      intermediatePassphrase: {
+        type: 'string',
+        minLength: 1,
+      },
+    },
+    required: [
+      'hostname',
+      'passphrase',
+      'intermediatePassphrase',
+    ],
+  },
 };

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -46,12 +46,16 @@ router.post('/intermediate', async(req, res) => {
       return res.status(400).send({ error: 'Invalid request body' });
     }
     const validator = config.getValidator();
-    if (!validator.validateSchema('new', req.body)) {
+    if (!validator.validateSchema('intermediate', req.body)) {
       logger.error('Invalid request body: schema validation failed');
       return res.status(400).send({ error: 'Invalid request body: schema validation failed' });
     }
-    const { hostname, passphrase } = req.body;
-    const ca = await controller.newIntermediateCA(hostname, passphrase);
+    const {
+      hostname,
+      passphrase,
+      intermediatePassphrase,
+    } = req.body;
+    const ca = await controller.newIntermediateCA(hostname, passphrase, intermediatePassphrase);
     return res.send(ca);
   } catch (err) {
     logger.error(`Error creating intermediate CA: ${err.message}`);

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -1,5 +1,12 @@
 jest.mock('../src/resources/certificateRequest');
 jest.mock('../src/resources/ca');
+jest.mock('crypto', () => {
+  const actual = jest.requireActual('crypto');
+  return {
+    ...actual,
+    generateKeyPair: jest.fn((type, opts, cb) => cb(null, 'pub', 'priv')),
+  };
+});
 
 const CertificateRequest = require('../src/resources/certificateRequest');
 const CA = require('../src/resources/ca');
@@ -41,7 +48,7 @@ describe('certController', () => {
     const fs = require('fs');
     jest.spyOn(fs.promises, 'mkdir').mockResolvedValue();
     jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
-    const result = await controller.newIntermediateCA('intermediate.example.com', 'pass');
+    const result = await controller.newIntermediateCA('intermediate.example.com', 'pass', 'intpass');
     expect(result).toEqual({ certificate: 'cert', privateKey: 'priv', hostname: 'intermediate.example.com' });
     expect(fs.promises.writeFile).toHaveBeenCalled();
     fs.promises.mkdir.mockRestore();

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -59,7 +59,8 @@ describe('certRouter', () => {
     controller.newIntermediateCA.mockResolvedValue({ ok: true });
     const res = await request(app)
       .post('/intermediate')
-      .send({ hostname: 'intermediate.example.com', passphrase: 'p' });
+      .send({ hostname: 'intermediate.example.com', passphrase: 'p', intermediatePassphrase: 'int' });
     expect(res.body).toEqual({ ok: true });
+    expect(controller.newIntermediateCA).toHaveBeenCalledWith('intermediate.example.com', 'p', 'int');
   });
 });


### PR DESCRIPTION
## Summary
- allow providing a passphrase for intermediate certificate keys
- encrypt intermediate private keys using crypto.generateKeyPair
- adapt CertificateRequest to accept pre-generated key pairs
- update setup script and controller
- adjust controller tests for new parameter
- add schema and router updates for intermediate passphrase
- support PKCS#8 key decryption

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848cd69dc148327a85efefdf624cbd2