### PR TITLE
Add CA store validation utility

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,10 +4,17 @@
 const app = require('./src/app');
 const config = require('./src/resources/config')();
 const logger = require('./src/utils/logger');
+const { validateStore } = require('./src/utils/storeValidator');
 
 const serverConfig = config.getServerConfig();
 
 const { port } = serverConfig;
+
+validateStore(config.getStoreDirectory())
+  .catch((err) => {
+    logger.error(`Store validation failed: ${err.message}`);
+    process.exit(1);
+  });
 
 app.listen(port, (err) => {
   if (err) {

--- a/src/utils/storeValidator.js
+++ b/src/utils/storeValidator.js
@@ -1,0 +1,56 @@
+const fs = require('fs').promises;
+const path = require('path');
+const logger = require('./logger');
+
+/**
+ * Ensure a file exists at the given path, creating it with default contents when missing.
+ *
+ * @param {string} filePath - Path of the file to check.
+ * @param {string|Object} defaultContents - Contents to write if the file is missing.
+ * @returns {Promise<boolean>} Resolves true when a file was created.
+ */
+async function ensureFile(filePath, defaultContents) {
+  try {
+    await fs.access(filePath);
+    return false;
+  } catch {
+    const data = typeof defaultContents === 'string'
+      ? defaultContents
+      : `${JSON.stringify(defaultContents, null, 2)}\n`;
+    await fs.writeFile(filePath, data, { encoding: 'utf-8' });
+    logger.info(`Created missing store file: ${path.basename(filePath)}`);
+    return true;
+  }
+}
+
+/**
+ * Validate and initialize the certificate store structure.
+ *
+ * @param {string} storeDirectory - Path to the CA store.
+ * @returns {Promise<string[]>} List of files or directories created.
+ */
+async function validateStore(storeDirectory) {
+  const created = [];
+  const intDir = path.join(storeDirectory, 'intermediates');
+  try {
+    await fs.access(intDir);
+  } catch {
+    await fs.mkdir(intDir, { recursive: true });
+    logger.info('Created missing store directory: intermediates');
+    created.push('intermediates');
+  }
+
+  if (await ensureFile(path.join(storeDirectory, 'serial'), '1000000')) {
+    created.push('serial');
+  }
+  if (await ensureFile(path.join(storeDirectory, 'log.json'), { requests: [] })) {
+    created.push('log.json');
+  }
+  if (await ensureFile(path.join(storeDirectory, 'revoked.json'), { certs: [] })) {
+    created.push('revoked.json');
+  }
+
+  return created;
+}
+
+module.exports = { validateStore, ensureFile };

--- a/tests/storeValidator.test.js
+++ b/tests/storeValidator.test.js
@@ -1,0 +1,81 @@
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const { validateStore } = require('../src/utils/storeValidator');
+
+async function createStore(opts = {}) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'store-'));
+  if (!opts.skipIntermediates) {
+    await fs.mkdir(path.join(dir, 'intermediates'), { recursive: true });
+  }
+  if (!opts.skipSerial) {
+    await fs.writeFile(path.join(dir, 'serial'), '1');
+  }
+  if (!opts.skipLog) {
+    await fs.writeFile(path.join(dir, 'log.json'), JSON.stringify({ requests: [] }));
+  }
+  if (!opts.skipRevoked) {
+    await fs.writeFile(path.join(dir, 'revoked.json'), JSON.stringify({ certs: [] }));
+  }
+  return dir;
+}
+
+async function cleanup(dir) {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+describe('validateStore utility', () => {
+  test('creates all files when store empty', async() => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'store-'));
+    const created = await validateStore(dir);
+    expect(created).toEqual(expect.arrayContaining(['serial', 'log.json', 'revoked.json', 'intermediates']));
+    await cleanup(dir);
+  });
+
+  test('creates missing serial file', async() => {
+    const dir = await createStore({ skipSerial: true });
+    const created = await validateStore(dir);
+    expect(created).toContain('serial');
+    expect(created.length).toBe(1);
+    await cleanup(dir);
+  });
+
+  test('creates missing log.json file', async() => {
+    const dir = await createStore({ skipLog: true });
+    const created = await validateStore(dir);
+    expect(created).toContain('log.json');
+    expect(created.length).toBe(1);
+    await cleanup(dir);
+  });
+
+  test('creates missing revoked.json file', async() => {
+    const dir = await createStore({ skipRevoked: true });
+    const created = await validateStore(dir);
+    expect(created).toContain('revoked.json');
+    expect(created.length).toBe(1);
+    await cleanup(dir);
+  });
+
+  test('creates missing intermediates directory', async() => {
+    const dir = await createStore({ skipIntermediates: true });
+    const created = await validateStore(dir);
+    expect(created).toContain('intermediates');
+    expect(created.length).toBe(1);
+    await cleanup(dir);
+  });
+
+  test('no changes when all files present', async() => {
+    const dir = await createStore();
+    const created = await validateStore(dir);
+    expect(created).toEqual([]);
+    await cleanup(dir);
+  });
+
+  test('idempotent across calls', async() => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'store-'));
+    await validateStore(dir);
+    const created = await validateStore(dir);
+    expect(created).toEqual([]);
+    await cleanup(dir);
+  });
+});


### PR DESCRIPTION
## Summary
- add `validateStore` utility to create required CA store files
- use the utility on startup
- test store validator behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a23be4bd883279a5fee54113e0eb0