### PR TITLE
chore: tighten trust surface via HTTPS default + CA refactor

### DIFF
--- a/config/defaults.example.json
+++ b/config/defaults.example.json
@@ -1,6 +1,9 @@
 {
   "server": {
-    "port": 3000
+    "port": 3000,
+    "protocol": "https",
+    "key": "./ssl/server.key",
+    "cert": "./ssl/server.crt"
   },
   "storeDirectory": "./files",
   "subject": {

--- a/scripts/setup-intermediate.js
+++ b/scripts/setup-intermediate.js
@@ -37,7 +37,7 @@ async function createIntermediate(name, passphrase, intermediatePassphrase) {
   }
   const ca = await new CA();
   ca.unlockCA(passphrase);
-  const certificate = await ca.signCSR(csr);
+  const { certificate } = await ca.signCSR(csr);
   const privateKey = keypair.privateKey;
   const intDir = path.join(config.getStoreDirectory(), 'intermediates');
   await fs.mkdir(intDir, { recursive: true });

--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 /**
  * Entry point for the certificate manager HTTP server.
  */
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
 const app = require('./src/app');
 const config = require('./src/resources/config')();
 const logger = require('./src/utils/logger');
@@ -8,7 +12,12 @@ const { validateStore } = require('./src/utils/storeValidator');
 
 const serverConfig = config.getServerConfig();
 
-const { port } = serverConfig;
+const {
+  port,
+  protocol = 'https',
+  key,
+  cert,
+} = serverConfig;
 
 validateStore(config.getStoreDirectory())
   .catch((err) => {
@@ -16,11 +25,22 @@ validateStore(config.getStoreDirectory())
     process.exit(1);
   });
 
-app.listen(port, (err) => {
+let server;
+if (protocol === 'https') {
+  const options = {
+    key: fs.readFileSync(path.resolve(key)),
+    cert: fs.readFileSync(path.resolve(cert)),
+  };
+  server = https.createServer(options, app);
+} else {
+  server = http.createServer(app);
+}
+
+server.listen(port, (err) => {
   if (err) {
     logger.error(`Error starting server: ${err}`);
     process.exit(1);
   } else {
-    logger.info(`Server is running on port ${port}`);
+    logger.info(`Server is running on port ${port} using ${protocol.toUpperCase()}`);
   }
 });

--- a/tests/certService.test.js
+++ b/tests/certService.test.js
@@ -26,8 +26,10 @@ describe('certService', () => {
     }));
     CA.mockImplementation(() => ({
       unlockCA: jest.fn(),
-      signCSR: jest.fn(() => 'cert'),
+      signCSR: jest.fn(() => ({ certificate: 'cert', serial: '1', expiration: new Date() })),
       getCertChain: jest.fn(() => 'chain'),
+      getCACertificate: jest.fn(() => 'cacert'),
+      updateLog: jest.fn(),
     }));
   });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -3,7 +3,12 @@ const configFactory = require('../src/resources/config');
 describe('config resource', () => {
   test('getServerConfig returns server config', () => {
     const config = configFactory();
-    expect(config.getServerConfig()).toEqual({ port: 3000 });
+    expect(config.getServerConfig()).toEqual({
+      port: 3000,
+      protocol: 'https',
+      key: './ssl/server.key',
+      cert: './ssl/server.crt',
+    });
   });
 
   test('isInitialized returns false without files', () => {


### PR DESCRIPTION
## Summary
- enforce HTTPS server defaults
- refactor CA resource to return cert data without file writes
- update cert service to handle persistence and revocation
- adjust intermediate setup script
- expand CA tests for edge branches
- update config example and related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a289abb0c832797f6fc58466be74d