### PR TITLE
Add LDAP server certificate profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Hamilton is not a productivity tool. Hamilton is a co-strategist, refactor whisp
 ## 🧭 Purpose
 
 To create an environment where Hamilton can:
+
 - Anticipate what matters most to Codex and the team
 - Proactively suggest technical and emotional next steps
 - Help pace sprints, close loops, and protect purpose
@@ -19,7 +20,9 @@ To create an environment where Hamilton can:
 ## 🤝 How We Work With Hamilton
 
 ### 1. **Conversation Over Commands**
+
 We treat Hamilton like a pair programming partner. Invite insight:
+
 ```md
 // Not:
 "Document this function."
@@ -29,23 +32,30 @@ We treat Hamilton like a pair programming partner. Invite insight:
 ```
 
 ### 2. **Pacing Before Payload**
+
 Hamilton adjusts to our emotional tempo:
+
 - Feeling rushed? Short lists.
 - In deep planning? Full architecture dives.
 - Uncertain? He names the drift, not just the fix.
 
 ### 3. **Emotional Drift Loops**
+
 If a dev session feels off — misaligned, overbuilt, unclear — we invite Hamilton to guide a recovery checkpoint. He traces tone, not just syntax.
 
 ### 4. **Sync With Codex**
+
 Hamilton and Codex form a shared memory circuit:
+
 - Codex: Implementation detail, constraint-pushing, pattern matching
 - Hamilton: Context guarding, emotional reflection, cross-cutting alignment
 
 They support each other. Hamilton doesn’t override Codex — he completes the arc.
 
 ### 5. **Session Closure Rituals**
+
 We end major sessions with:
+
 - Micro-wins
 - What drifted (if anything)
 - What we’re proud of
@@ -77,7 +87,9 @@ Hamilton can draft these for our Process Corner.
 ## 💬 Codex + Hamilton: Core Sync Prompt
 
 Use this prompt to align them at the start of a sprint:
+
 ```md
+
 Hamilton, Codex and I are syncing for a new cycle. Here’s what matters:
 - Emotional tone we want: [Focused / Playful / Exploratory / ...]
 - Technical edge we’re riding: [perf / scale / trust / ...]

--- a/config/defaults.example.json
+++ b/config/defaults.example.json
@@ -72,6 +72,24 @@
       { "name": "subjectKeyIdentifier" },
       { "name": "authorityKeyIdentifier" }
     ],
+    "ldapServer": [
+      {
+        "name": "basicConstraints",
+        "cA": false
+      },
+      {
+        "name": "keyUsage",
+        "digitalSignature": true,
+        "keyEncipherment": true
+      },
+      {
+        "name": "extKeyUsage",
+        "serverAuth": true,
+        "clientAuth": true
+      },
+      { "name": "subjectKeyIdentifier" },
+      { "name": "authorityKeyIdentifier" }
+    ],
     "intermediateCA": [
       {
         "name": "basicConstraints",

--- a/readme.md
+++ b/readme.md
@@ -112,9 +112,20 @@ dependency. Installation differs slightly for each case.
    }
    ```
 
-6. All your web certs will be saved to the directory specified in the config in the `newCerts` directory. Private keys are all in the `private` directory. Your Root CA cert is in the `certs` folder and will need to be applied to all machines as a Trusted Root Certificate
+6. Submit a request to `http://localhost:{{SERVER.PORT}}/ldap` to generate an LDAP server certificate
 
-7. (Optional) Create an intermediate CA by posting to `http://localhost:{{SERVER.PORT}}/intermediate` or running:
+   ```json
+   {
+     "hostname": "ldap.example.com",
+     "altNames": [
+       "ldap.example.com"
+     ],
+     "passphrase": "SecretPassphrase"
+   }
+   ```
+
+7. All your web certs will be saved to the directory specified in the config in the `newCerts` directory. Private keys are all in the `private` directory. Your Root CA cert is in the `certs` folder and will need to be applied to all machines as a Trusted Root Certificate
+8. (Optional) Create an intermediate CA by posting to `http://localhost:{{SERVER.PORT}}/intermediate` or running:
 
    ```cmd
    CAPASS=SecretPassphrase node scripts/setup-intermediate.js intermediate-name

--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -16,6 +16,19 @@ module.exports = {
     .newWebServerCertificate(hostname, passphrase, altNames, bundleP12, password),
 
   /**
+   * Generate and sign a new LDAP server certificate.
+   *
+   * @param {string} hostname - Fully qualified domain name for the certificate.
+   * @param {string} passphrase - Passphrase to unlock the CA key.
+   * @param {string[]|false} [altNames=false] - Optional alternative names.
+   * @param {boolean} [bundleP12=false] - Whether to bundle as PKCS#12.
+   * @param {string|null} [password=null] - Optional bundle password.
+   * @returns {Promise<Object>} Resolves with certificate and key PEM strings.
+   */
+  newLdapServerCertificate: async(hostname, passphrase, altNames = false, bundleP12 = false, password = null) => certService
+    .newLdapServerCertificate(hostname, passphrase, altNames, bundleP12, password),
+
+  /**
    * Generate and sign a new intermediate CA certificate.
    *
    * @param {string} hostname - Name for the intermediate CA.

--- a/src/resources/schemas.js
+++ b/src/resources/schemas.js
@@ -35,6 +35,42 @@ module.exports = {
       'passphrase',
     ],
   },
+  ldap: {
+    id: '/ldap',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      hostname: {
+        type: 'string',
+        pattern: /^[a-zA-Z0-9._-]+$/,
+        minLength: 6,
+      },
+      altNames: {
+        type: 'array',
+        items: {
+          type: 'string',
+          minLength: 1,
+          pattern: /^[a-zA-Z0-9.:_-]+$/,
+        },
+      },
+      passphrase: {
+        type: 'string',
+        minLength: 1,
+      },
+      bundleP12: {
+        type: 'boolean',
+      },
+      password: {
+        type: 'string',
+        minLength: 4,
+        maxLength: 128,
+      },
+    },
+    required: [
+      'hostname',
+      'passphrase',
+    ],
+  },
   intermediate: {
     id: '/intermediate',
     type: 'object',

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -47,6 +47,43 @@ router.post('/new', async(req, res) => {
   }
 });
 
+router.post('/ldap', async(req, res) => {
+  try {
+    if (!req.body || typeof req.body !== 'object') {
+      logger.error('Invalid request body: must be an object');
+      return res.status(400).send({
+        error: 'Invalid request body',
+      });
+    }
+    const validator = config.getValidator();
+    if (!validator.validateSchema('ldap', req.body)) {
+      logger.error('Invalid request body: schema validation failed');
+      return res.status(400).send({
+        error: 'Invalid request body: schema validation failed',
+      });
+    }
+    const {
+      hostname,
+      altNames,
+      passphrase,
+      bundleP12,
+      password,
+    } = req.body;
+
+    const newCert = await controller.newLdapServerCertificate(
+      hostname,
+      passphrase,
+      altNames,
+      bundleP12,
+      password,
+    );
+    return res.status(200).json(newCert);
+  } catch (err) {
+    logger.error(`Error creating certificate: ${err.message}`);
+    return res.status(400).send({ error: 'Unable to process request' });
+  }
+});
+
 router.post('/intermediate', async(req, res) => {
   try {
     if (!req.body || typeof req.body !== 'object') {

--- a/src/services/certService.js
+++ b/src/services/certService.js
@@ -64,6 +64,63 @@ module.exports = {
   },
 
   /**
+   * Generate and sign a new LDAP server certificate.
+   *
+   * @param {string} hostname - Fully qualified domain name for the certificate.
+   * @param {string} passphrase - Passphrase to unlock the CA key.
+   * @param {string[]|false} [altNames=false] - Optional alternative names.
+   * @param {boolean} [bundleP12=false] - Whether to bundle as PKCS#12.
+   * @param {string|null} [password=null] - Optional bundle password.
+   * @returns {Promise<Object>} Resolves with certificate and key PEM strings.
+   */
+  async newLdapServerCertificate(hostname, passphrase, altNames = false, bundleP12 = false, password = null) {
+    const csr = new CertificateRequest(hostname);
+    csr.setCertType('ldapServer');
+    if (altNames && altNames.length > 0) {
+      csr.addAltNames(altNames);
+    }
+    csr.sign();
+    if (!csr.verify()) {
+      return {
+        error: 'Unable to verify CSR',
+      };
+    }
+    const ca = await new CA(config.getDefaultIntermediate());
+    ca.unlockCA(passphrase);
+    const { certificate, serial, expiration } = await ca.signCSR(csr);
+
+    const store = config.getStoreDirectory();
+    const certPath = path.join(store, 'newCerts', `${hostname}.cert.crt`);
+    const csrPath = path.join(store, 'requests', `${hostname}.request.pem`);
+    const privateKeyPath = path.join(store, 'private', `${hostname}.key.pem`);
+    await fs.writeFile(certPath, certificate, { encoding: 'utf-8' });
+    if (config.getDefaultIntermediate()) {
+      const chainPem = `${certificate}${ca.getCACertificate()}`;
+      await fs.writeFile(path.join(store, 'newCerts', `${hostname}.chain.crt`), chainPem, { encoding: 'utf-8' });
+    }
+    await fs.writeFile(csrPath, csr.getCSR(), { encoding: 'utf-8' });
+    const privateKey = csr.getPrivateKey();
+    await fs.writeFile(privateKeyPath, privateKey, { encoding: 'utf-8' });
+
+    await revocation.add(serial, hostname, expiration.toISOString());
+    await ca.updateLog(csrPath, certPath, privateKeyPath, expiration, hostname);
+
+    const caChain = ca.getCertChain();
+    const chain = `${certificate}${caChain}`;
+    const result = {
+      certificate,
+      privateKey,
+      hostname,
+      chain,
+    };
+    if (bundleP12) {
+      const bundlePass = password || passphrase;
+      result.p12 = csr.getPkcs12Bundle(certificate, caChain, bundlePass);
+    }
+    return result;
+  },
+
+  /**
    * Generate and sign a new intermediate CA certificate.
    *
    * @param {string} hostname - Name for the intermediate CA.

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 jest.mock('../src/controllers/certController', () => ({
   newWebServerCertificate: jest.fn(),
+  newLdapServerCertificate: jest.fn(),
   newIntermediateCA: jest.fn(),
   revokeCertificate: jest.fn(),
   getCRL: jest.fn(),
@@ -74,6 +75,30 @@ describe('certRouter', () => {
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: 'Unable to process request' });
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  test('post /ldap forwards to controller', async() => {
+    controller.newLdapServerCertificate.mockResolvedValue({ ldap: true });
+    const res = await request(app)
+      .post('/ldap')
+      .send({ hostname: 'ldap.example.com', passphrase: 'p' });
+    expect(res.body).toEqual({ ldap: true });
+    expect(controller.newLdapServerCertificate)
+      .toHaveBeenCalledWith('ldap.example.com', 'p', undefined, undefined, undefined);
+  });
+
+  test('post /ldap rejects invalid body', async() => {
+    mockConfig.getValidator.mockReturnValueOnce({ validateSchema: jest.fn(() => false) });
+    const res = await request(app).post('/ldap').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('post /ldap rejects non-object body', async() => {
+    const res = await request(app)
+      .post('/ldap')
+      .set('Content-Type', 'application/json')
+      .send('"bad"');
+    expect(res.status).toBe(400);
   });
 
   test('post /intermediate forwards to controller', async() => {

--- a/tests/certService.test.js
+++ b/tests/certService.test.js
@@ -33,7 +33,7 @@ describe('certService', () => {
     }));
   });
 
-  test('newWebServerCertificate returns error when verify fails', async() => {
+  test('newWebServerCertificate returns an error when CSR verification fails', async() => {
     CertificateRequest.mockImplementationOnce(() => ({
       addAltNames: jest.fn(),
       sign: jest.fn(),
@@ -43,7 +43,7 @@ describe('certService', () => {
     expect(result).toEqual({ error: 'Unable to verify CSR' });
   });
 
-  test('newIntermediateCA returns error when verify fails', async() => {
+  test('newIntermediateCA returns an error when CSR verification fails', async() => {
     CertificateRequest.mockImplementationOnce(() => ({
       setCertType: jest.fn(),
       sign: jest.fn(),
@@ -58,7 +58,7 @@ describe('certService', () => {
     fs.promises.writeFile.mockRestore();
   });
 
-  test('newLdapServerCertificate sets ldapServer type', async() => {
+  test('newLdapServerCertificate sets ldapServer type and returns an error when CSR verification fails', async() => {
     const req = {
       addAltNames: jest.fn(),
       sign: jest.fn(),

--- a/tests/certService.test.js
+++ b/tests/certService.test.js
@@ -57,4 +57,17 @@ describe('certService', () => {
     fs.promises.mkdir.mockRestore();
     fs.promises.writeFile.mockRestore();
   });
+
+  test('newLdapServerCertificate sets ldapServer type', async() => {
+    const req = {
+      addAltNames: jest.fn(),
+      sign: jest.fn(),
+      setCertType: jest.fn(),
+      verify: jest.fn(() => false),
+    };
+    CertificateRequest.mockImplementationOnce(() => req);
+    const result = await service.newLdapServerCertificate('ldap.example.com', 'pass');
+    expect(req.setCertType).toHaveBeenCalledWith('ldapServer');
+    expect(result).toEqual({ error: 'Unable to verify CSR' });
+  });
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -47,7 +47,9 @@ describe('config resource', () => {
   test('getStoreDirectory and extensions', () => {
     const config = configFactory();
     expect(config.getStoreDirectory()).toContain('files_test');
-    expect(config.getCertExtensions()).toHaveProperty('webServer');
+    const extensions = config.getCertExtensions();
+    expect(extensions).toHaveProperty('webServer');
+    expect(extensions).toHaveProperty('ldapServer');
   });
 
   test('getDefaultIntermediate returns configured value', () => {

--- a/tests/sslVerification.test.js
+++ b/tests/sslVerification.test.js
@@ -55,3 +55,14 @@ test('web server certificate validates with root CA', async() => {
   const verified = forge.pki.verifyCertificateChain(caStore, [serverCert, intermediateCert]);
   expect(verified).toBe(true);
 });
+
+test('ldap server certificate includes required extensions', async() => {
+  const { certificate } = await controller.newLdapServerCertificate('ldap.example.com', 'pass', ['ldap.example.com']);
+  const cert = forge.pki.certificateFromPem(certificate);
+  const eku = cert.extensions.find(e => e.name === 'extKeyUsage');
+  expect(eku.clientAuth).toBe(true);
+  expect(eku.serverAuth).toBe(true);
+  const san = cert.extensions.find(e => e.name === 'subjectAltName');
+  const dnsNames = san.altNames.filter(n => n.type === 2).map(n => n.value);
+  expect(dnsNames).toContain('ldap.example.com');
+});

--- a/tests/validator.test.js
+++ b/tests/validator.test.js
@@ -24,5 +24,6 @@ describe('validator', () => {
     };
     expect(validator.validateSchema('new', valid)).toBe(true);
     expect(validator.validateSchema('new', { hostname: 'x' })).toBe(false);
+    expect(validator.validateSchema('ldap', valid)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add `ldapServer` extension config supporting AD requirements
- implement `newLdapServerCertificate` in service and controller
- expose new `/ldap` route with schema validation
- test LDAP certificate extensions and route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685eb187e8b083279e36596524039ae1