### PR TITLE
Persist p12 bundles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ dependency. Installation differs slightly for each case.
    }
    ```
 
-7. All your web certs will be saved to the directory specified in the config in the `newCerts` directory. Private keys are all in the `private` directory. Your Root CA cert is in the `certs` folder and will need to be applied to all machines as a Trusted Root Certificate
+7. All your web certs will be saved to the directory specified in the config in the `newCerts` directory. Private keys are all in the `private` directory. Your Root CA cert is in the `certs` folder and will need to be applied to all machines as a Trusted Root Certificate. If `"bundleP12": true` is included in the request body, a PKCS#12 bundle will also be saved as `newCerts/<hostname>.bundle.p12`.
 8. (Optional) Create an intermediate CA by posting to `http://localhost:{{SERVER.PORT}}/intermediate` or running:
 
    ```cmd

--- a/src/services/certService.js
+++ b/src/services/certService.js
@@ -5,6 +5,15 @@ const CertificateRequest = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 const revocation = require('../resources/revocation');
 const config = require('../resources/config')();
+const logger = require('../utils/logger');
+
+async function writeP12ToFile(hostname, p12b64) {
+  const store = config.getStoreDirectory();
+  const bundlePath = path.join(store, 'newCerts', `${hostname}.bundle.p12`);
+  await fs.writeFile(bundlePath, Buffer.from(p12b64, 'base64'), { mode: 0o600 });
+  logger.info(`Saved PKCS#12 bundle: ${bundlePath}`);
+  return bundlePath;
+}
 
 module.exports = {
   /**
@@ -59,6 +68,7 @@ module.exports = {
     if (bundleP12) {
       const bundlePass = password || passphrase;
       result.p12 = csr.getPkcs12Bundle(certificate, caChain, bundlePass);
+      await writeP12ToFile(hostname, result.p12);
     }
     return result;
   },
@@ -116,6 +126,7 @@ module.exports = {
     if (bundleP12) {
       const bundlePass = password || passphrase;
       result.p12 = csr.getPkcs12Bundle(certificate, caChain, bundlePass);
+      await writeP12ToFile(hostname, result.p12);
     }
     return result;
   },

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -67,6 +67,16 @@ describe('certController', () => {
     expect(CertificateRequest.mock.results[0].value.getPkcs12Bundle).toHaveBeenCalledWith('cert', 'caCertroot', 'p12pass');
   });
 
+  test('p12 bundle written to disk when requested', async() => {
+    const fs = require('fs');
+    await controller.newWebServerCertificate('foo.example.com', 'pass', false, true, 'p12pass');
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('foo.example.com.bundle.p12'),
+      expect.any(Buffer),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+
   test('newIntermediateCA writes files', async() => {
     const fs = require('fs');
     const result = await controller.newIntermediateCA('intermediate.example.com', 'pass', 'intpass');


### PR DESCRIPTION
## Summary
- add helper to save PKCS#12 bundles
- write bundles when `/new` or `/ldap` requests include `bundleP12`
- document bundle path in README
- cover bundle file creation in tests

## Testing
- `CI=true npx jest --coverage --testPathIgnorePatterns sslVerification.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685eeb7b772c8327b910ba3ab1aaf6cc