### PR TITLE
Enforce intermediate requirement

### DIFF
--- a/config/defaults.example.json
+++ b/config/defaults.example.json
@@ -36,6 +36,7 @@
   "validDomains": [
     "example.com"
   ],
+  "requireIntermediate": true,
   "defaultIntermediate": "intermediate",
   "extensions": {
     "CA": [

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ dependency. Installation differs slightly for each case.
    "validDomains": [
      "example.com" // <- This is used to validate cert request hostnames not alternate names
    ],
+   "requireIntermediate": true, // <- Prevents root from issuing leaf certs
    "defaultIntermediate": "intermediate", // <- Intermediate CA used for server certificates
    ...
    ```
@@ -131,7 +132,7 @@ dependency. Installation differs slightly for each case.
    CAPASS=SecretPassphrase node scripts/setup-intermediate.js intermediate-name
    ```
 
-   This intermediate certificate will be placed under `files/intermediates/` and used by default for server certificates if `defaultIntermediate` is set in the configuration. When a server certificate is issued it is saved alongside a `.chain.crt` file containing both the server and intermediate certificates and the HTTP response includes this chain in a `chain` property. Present this chain so clients can validate the path using only the trusted root certificate.
+   This intermediate certificate will be placed under `files/intermediates/` and used by default for server certificates if `defaultIntermediate` is set in the configuration. When `requireIntermediate` is `true`, the application refuses to issue leaf certificates with the root key. When a server certificate is issued it is saved alongside a `.chain.crt` file containing both the server and intermediate certificates and the HTTP response includes this chain in a `chain` property. Present this chain so clients can validate the path using only the trusted root certificate.
 
 ## Roadmap / Features
 

--- a/src/resources/config.js
+++ b/src/resources/config.js
@@ -38,6 +38,10 @@ class Config {
     });
     this.#private.defaultIntermediate =
       this.#private.configuration.defaultIntermediate || null;
+    this.#private.requireIntermediate =
+      this.#private.configuration.requireIntermediate !== undefined
+        ? this.#private.configuration.requireIntermediate
+        : true;
     this.#private.storeDirectory = configurationFiles.storeDirectory;
     this.#private.validator = new Validator(this.#private.configuration);
     this.validateHostname = this.#private.validator.hostname;
@@ -110,6 +114,10 @@ class Config {
 
   getDefaultIntermediate() {
     return this.#private.defaultIntermediate;
+  }
+
+  getRequireIntermediate() {
+    return this.#private.requireIntermediate;
   }
 }
 

--- a/src/services/certService.js
+++ b/src/services/certService.js
@@ -37,6 +37,9 @@ module.exports = {
         error: 'Unable to verify CSR',
       };
     }
+    if (!config.getDefaultIntermediate() && config.getRequireIntermediate()) {
+      return { error: 'Root CA may not issue leaf certs' };
+    }
     const ca = await new CA(config.getDefaultIntermediate());
     ca.unlockCA(passphrase);
     const { certificate, serial, expiration } = await ca.signCSR(csr);
@@ -94,6 +97,9 @@ module.exports = {
       return {
         error: 'Unable to verify CSR',
       };
+    }
+    if (!config.getDefaultIntermediate() && config.getRequireIntermediate()) {
+      return { error: 'Root CA may not issue leaf certs' };
     }
     const ca = await new CA(config.getDefaultIntermediate());
     ca.unlockCA(passphrase);

--- a/tests/certService.test.js
+++ b/tests/certService.test.js
@@ -8,6 +8,7 @@ jest.mock('crypto', () => {
   };
 });
 
+const path = require('path');
 const CertificateRequest = require('../src/resources/certificateRequest');
 const CA = require('../src/resources/ca');
 const service = require('../src/services/certService');
@@ -69,5 +70,61 @@ describe('certService', () => {
     const result = await service.newLdapServerCertificate('ldap.example.com', 'pass');
     expect(req.setCertType).toHaveBeenCalledWith('ldapServer');
     expect(result).toEqual({ error: 'Unable to verify CSR' });
+  });
+
+  test('newWebServerCertificate rejects root issuance when enforced', async() => {
+    const orig = process.env.CONFIG_PATH;
+    const cfg = path.join(__dirname, 'noIntermediate.json');
+    jest.resetModules();
+    process.env.CONFIG_PATH = cfg;
+    const CR = require('../src/resources/certificateRequest');
+    const CARes = require('../src/resources/ca');
+    CR.mockImplementation(() => ({
+      addAltNames: jest.fn(),
+      sign: jest.fn(),
+      setCertType: jest.fn(),
+      verify: jest.fn(() => true),
+      getPrivateKey: jest.fn(() => 'priv'),
+      getPkcs12Bundle: jest.fn(() => 'p12data'),
+    }));
+    CARes.mockImplementation(() => ({
+      unlockCA: jest.fn(),
+      signCSR: jest.fn(() => ({ certificate: 'cert', serial: '1', expiration: new Date() })),
+      getCertChain: jest.fn(() => 'chain'),
+      getCACertificate: jest.fn(() => 'cacert'),
+      updateLog: jest.fn(),
+    }));
+    const svc = require('../src/services/certService');
+    const result = await svc.newWebServerCertificate('foo.example.com', 'pass');
+    expect(result).toEqual({ error: 'Root CA may not issue leaf certs' });
+    process.env.CONFIG_PATH = orig;
+  });
+
+  test('newLdapServerCertificate rejects root issuance when enforced', async() => {
+    const orig = process.env.CONFIG_PATH;
+    const cfg = path.join(__dirname, 'noIntermediate.json');
+    jest.resetModules();
+    process.env.CONFIG_PATH = cfg;
+    const CR = require('../src/resources/certificateRequest');
+    const CARes = require('../src/resources/ca');
+    CR.mockImplementation(() => ({
+      addAltNames: jest.fn(),
+      sign: jest.fn(),
+      setCertType: jest.fn(),
+      verify: jest.fn(() => true),
+      getPrivateKey: jest.fn(() => 'priv'),
+      getPkcs12Bundle: jest.fn(() => 'p12data'),
+    }));
+    CARes.mockImplementation(() => ({
+      unlockCA: jest.fn(),
+      signCSR: jest.fn(() => ({ certificate: 'cert', serial: '1', expiration: new Date() })),
+      getCertChain: jest.fn(() => 'chain'),
+      getCACertificate: jest.fn(() => 'cacert'),
+      updateLog: jest.fn(),
+    }));
+    const svc = require('../src/services/certService');
+    const result = await svc.newLdapServerCertificate('ldap.example.com', 'pass');
+    expect(result).toEqual({ error: 'Root CA may not issue leaf certs' });
+    process.env.CONFIG_PATH = orig;
   });
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -56,4 +56,9 @@ describe('config resource', () => {
     const config = configFactory();
     expect(config.getDefaultIntermediate()).toBe('intermediate');
   });
+
+  test('getRequireIntermediate returns configured value', () => {
+    const config = configFactory();
+    expect(config.getRequireIntermediate()).toBe(true);
+  });
 });

--- a/tests/noIntermediate.json
+++ b/tests/noIntermediate.json
@@ -1,0 +1,19 @@
+{
+  "server": {
+    "port": 3000,
+    "protocol": "https",
+    "key": "./ssl/server.key",
+    "cert": "./ssl/server.crt"
+  },
+  "storeDirectory": "./files_test",
+  "subject": {
+    "email": {"prompt": "Email", "shortName": "E", "default": "test@example.com"},
+    "organization": {"prompt": "Org", "shortName": "O", "default": "Test"},
+    "locality": {"prompt": "Local", "shortName": "L", "default": "Test"},
+    "state": {"prompt": "State", "shortName": "ST", "default": "Test"},
+    "country": {"prompt": "Country", "shortName": "C", "default": "US"}
+  },
+  "validDomains": ["example.com"],
+  "requireIntermediate": true,
+  "extensions": {}
+}


### PR DESCRIPTION
## Summary
- enforce intermediate CA check when issuing leaf certificates
- expose `requireIntermediate` in config and example defaults
- document intermediate requirement in README
- test failure cases when root CA issuance is disallowed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867e7b1105083279ef5bd5eb9388b69