### PR TITLE
Add certificate renewal endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,21 @@ dependency. Installation differs slightly for each case.
    }
    ```
 
-7. Issued certificates are written to the directory specified by `storeDirectory`.
+7. Renew an existing certificate (re-issuing with the same subject and SANs) by posting to `http://localhost:{{SERVER.PORT}}/renew`:
+
+   ```json
+   {
+     "serialNumber": "1234",
+     "passphrase": "SecretPassphrase",
+     "validityDays": 90,
+     "bundleP12": true,
+     "password": "optional-bundle-password"
+   }
+   ```
+
+   The server will reuse the stored subject and SANs, apply the requested validity when allowed by policy limits, and return updated certificate material (optionally including a PKCS#12 bundle).
+
+8. Issued certificates are written to the directory specified by `storeDirectory`.
 
    - Leaf certificates: `newCerts/`
    - Private keys: `private/`
@@ -155,7 +169,7 @@ dependency. Installation differs slightly for each case.
    If `"bundleP12": true` is included in the request body, a PKCS#12 bundle is also
    written to `newCerts/<hostname>.bundle.p12`.
 
-8. (Optional) Create an intermediate CA by posting to
+9. (Optional) Create an intermediate CA by posting to
    `http://localhost:{{SERVER.PORT}}/intermediate` or running:
 
    ```cmd

--- a/src/controllers/certController.js
+++ b/src/controllers/certController.js
@@ -32,6 +32,17 @@ module.exports = {
   },
 
   /**
+   * Renew an existing certificate using its serial number.
+   *
+   * @param {string} serialNumber - Serial number of the certificate to renew.
+   * @param {string} passphrase - Passphrase to unlock the CA key.
+   * @returns {Promise<Object>} Resolves with renewed certificate material.
+   */
+  renewCertificate: async(serialNumber, passphrase, bundleP12 = false, password = null, validityDays = null, performedBy = undefined) => {
+    return await certService.renewCertificate(serialNumber, passphrase, bundleP12, password, validityDays, performedBy);
+  },
+
+  /**
    * Generate and sign a new intermediate CA certificate.
    *
    * @param {string} hostname - Name for the intermediate CA.

--- a/src/resources/revocation.js
+++ b/src/resources/revocation.js
@@ -92,6 +92,17 @@ class Revocation {
       return expiration.getTime() > now.getTime();
     });
   }
+
+  /**
+   * Retrieve a certificate entry by serial number.
+   *
+   * @param {string|number} serialNumber - Serial to locate.
+   * @returns {Promise<Object|null>} Matching certificate record or null.
+   */
+  async getBySerial(serialNumber) {
+    const data = await this._load();
+    return data.certs.find((c) => c.serialNumber === serialNumber.toString()) || null;
+  }
 }
 
 module.exports = new Revocation();

--- a/src/resources/schemas.js
+++ b/src/resources/schemas.js
@@ -119,4 +119,35 @@ module.exports = {
     },
     required: ['serialNumber'],
   },
+  renew: {
+    id: '/renew',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      serialNumber: {
+        type: 'string',
+        pattern: /^\d+$/,
+      },
+      passphrase: {
+        type: 'string',
+        minLength: 1,
+      },
+      validityDays: {
+        type: 'integer',
+        minimum: 1,
+      },
+      bundleP12: {
+        type: 'boolean',
+      },
+      password: {
+        type: 'string',
+        minLength: 4,
+        maxLength: 128,
+      },
+    },
+    required: [
+      'serialNumber',
+      'passphrase',
+    ],
+  },
 };

--- a/src/routers/certRouter.js
+++ b/src/routers/certRouter.js
@@ -83,6 +83,60 @@ router.post('/new', async(req, res) => {
   }
 });
 
+router.post('/renew', async(req, res) => {
+  try {
+    if (!req.body || typeof req.body !== 'object' || Object.keys(req.body).length === 0) {
+      logger.error('Invalid request body: must be an object');
+      return res.status(400).send({
+        error: 'Invalid request body',
+      });
+    }
+    const validator = config.getValidator();
+    if (!validator.validateSchema('renew', req.body)) {
+      logger.error('Invalid request body: schema validation failed');
+      return res.status(400).send({
+        error: 'Invalid request body: schema validation failed',
+      });
+    }
+    const {
+      serialNumber,
+      passphrase,
+      bundleP12,
+      password,
+      validityDays,
+    } = req.body;
+
+    const limitsRenew = (config.getValidityLimits && config.getValidityLimits()) || { minDays: 1, maxDays: 397 };
+    let finalValidityRenew = null;
+    if (typeof validityDays !== 'undefined' && validityDays !== null) {
+      if (validityDays < limitsRenew.minDays || validityDays > limitsRenew.maxDays) {
+        logger.error(`Requested validityDays ${validityDays} out of allowed range`);
+        return res.status(400).send({ error: `validityDays must be between ${limitsRenew.minDays} and ${limitsRenew.maxDays}` });
+      }
+      finalValidityRenew = validityDays;
+    }
+
+    const renewed = await controller.renewCertificate(
+      serialNumber,
+      passphrase,
+      bundleP12,
+      password,
+      finalValidityRenew,
+      req.ip,
+    );
+    if (renewed?.error) {
+      const status = renewed.error === 'Serial not found' || renewed.error === 'Certificate is revoked'
+        ? 404
+        : 400;
+      return res.status(status).json(renewed);
+    }
+    return res.status(200).json(renewed);
+  } catch (err) {
+    logger.error(`Error renewing certificate: ${err.message}`);
+    return res.status(400).send({ error: 'Unable to process request' });
+  }
+});
+
 router.post('/ldap', async(req, res) => {
   try {
     if (!req.body || typeof req.body !== 'object' || Object.keys(req.body).length === 0) {

--- a/src/services/certService.js
+++ b/src/services/certService.js
@@ -1,6 +1,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const crypto = require('crypto');
+const forge = require('node-forge');
 const CertificateRequest = require('../resources/certificateRequest');
 const CA = require('../resources/ca');
 const revocation = require('../resources/revocation');
@@ -148,6 +149,142 @@ module.exports = {
       eventType: 'CERT_ISSUE',
       subject: hostname,
       serialNumber: serial.toString(),
+      performedBy,
+      validityDaysRequested: validityDays,
+      validityDaysApplied,
+    });
+    return result;
+  },
+
+  /**
+   * Renew an existing certificate using stored subject and SAN data.
+   *
+   * @param {string} serialNumber - Serial number of the certificate to renew.
+   * @param {string} passphrase - Passphrase to unlock the CA.
+   * @param {boolean} [bundleP12=false] - Whether to bundle as PKCS#12.
+   * @param {string|null} [password=null] - Optional bundle password.
+   * @returns {Promise<Object>} Resolves with renewed certificate and key material.
+   */
+  async renewCertificate(serialNumber, passphrase, bundleP12 = false, password = null, validityDays = null, performedBy = undefined) {
+    const existing = await revocation.getBySerial(serialNumber);
+    if (!existing) {
+      return { error: 'Serial not found' };
+    }
+    if (existing.revoked) {
+      return { error: 'Certificate is revoked' };
+    }
+
+    const limits = (config.getValidityLimits && config.getValidityLimits()) || { minDays: 1, maxDays: 397 };
+    let finalValidity = validityDays;
+    if (finalValidity !== null && (finalValidity < limits.minDays || finalValidity > limits.maxDays)) {
+      return { error: `validityDays must be between ${limits.minDays} and ${limits.maxDays}` };
+    }
+
+    const store = config.getStoreDirectory();
+    const certPath = path.join(store, 'newCerts', `${existing.hostname}.cert.crt`);
+    const csrPath = path.join(store, 'requests', `${existing.hostname}.request.pem`);
+    const privateKeyPath = path.join(store, 'private', `${existing.hostname}.key.pem`);
+
+    let certPem;
+    let privateKey;
+    try {
+      [certPem, privateKey] = await Promise.all([
+        fs.readFile(certPath, 'utf-8'),
+        fs.readFile(privateKeyPath, 'utf-8'),
+      ]);
+    } catch (err) {
+      logger.error(`Unable to load existing certificate material for ${existing.hostname}: ${err.message}`);
+      return { error: 'Original certificate material not found' };
+    }
+
+    const cert = forge.pki.certificateFromPem(certPem);
+    const cnField = (typeof cert.subject.getField === 'function')
+      ? cert.subject.getField('CN')
+      : (cert.subject.attributes || []).find((attr) => attr.shortName === 'CN');
+    if (!cnField || !cnField.value) {
+      return { error: 'Certificate subject is missing a common name' };
+    }
+    const hostname = cnField.value.toString().toLowerCase();
+
+    const sanExtension = (cert.extensions || []).find((ext) => ext.name === 'subjectAltName');
+    const altNames = [];
+    if (sanExtension && Array.isArray(sanExtension.altNames)) {
+      sanExtension.altNames.forEach((alt) => {
+        if (alt.type === 7 && alt.ip) {
+          altNames.push(alt.ip);
+        } else if (alt.type === 2 && alt.value) {
+          altNames.push(alt.value);
+        }
+      });
+    }
+
+    const extKeyUsage = (cert.extensions || []).find((ext) => ext.name === 'extKeyUsage');
+    const certType = extKeyUsage?.clientAuth ? 'ldapServer' : 'webServer';
+    if (finalValidity === null) {
+      const profileDefault = (config.getProfileValidity && config.getProfileValidity(certType)) || null;
+      if (profileDefault) {
+        if (profileDefault < limits.minDays || profileDefault > limits.maxDays) {
+          return { error: 'Invalid server configuration for profile validity' };
+        }
+        finalValidity = profileDefault;
+      }
+    }
+
+    const csr = new CertificateRequest(
+      hostname,
+      {
+        publicKey: forge.pki.publicKeyToPem(cert.publicKey),
+        privateKeyPEM: privateKey,
+      },
+    );
+    if (certType !== 'webServer') {
+      csr.setCertType(certType);
+    }
+    if (altNames.length > 0) {
+      csr.addAltNames(altNames);
+    }
+    csr.sign();
+    if (!csr.verify()) {
+      return {
+        error: 'Unable to verify CSR',
+      };
+    }
+    if (!config.getDefaultIntermediate() && config.getRequireIntermediate()) {
+      return { error: 'Root CA may not issue leaf certs' };
+    }
+    const ca = await new CA(config.getDefaultIntermediate());
+    ca.unlockCA(passphrase, performedBy);
+    const { certificate, serial, expiration, validityDaysApplied } = await ca.signCSR(csr, { validityDays: finalValidity });
+
+    await fs.writeFile(certPath, certificate, { encoding: 'utf-8' });
+    if (config.getDefaultIntermediate()) {
+      const chainPem = `${certificate}${ca.getCACertificate()}`;
+      await fs.writeFile(path.join(store, 'newCerts', `${hostname}.chain.crt`), chainPem, { encoding: 'utf-8' });
+    }
+    await fs.writeFile(csrPath, csr.getCSR(), { encoding: 'utf-8' });
+
+    await revocation.add(serial, hostname, expiration.toISOString());
+    await ca.updateLog(csrPath, certPath, privateKeyPath, expiration, hostname, validityDaysApplied);
+
+    const caChain = ca.getCertChain();
+    const chain = `${certificate}${caChain}`;
+    const result = {
+      certificate,
+      privateKey,
+      hostname,
+      chain,
+    };
+    if (bundleP12) {
+      const bundlePass = password || passphrase;
+      result.p12 = csr.getPkcs12Bundle(certificate, caChain, bundlePass);
+      await writeP12ToFile(hostname, result.p12);
+    }
+    logger.audit.info({
+      timestamp: new Date().toISOString(),
+      eventType: 'CERT_RENEW',
+      subject: hostname,
+      serialNumber: serial.toString(),
+      renewedFromSerial: serialNumber.toString(),
       performedBy,
       validityDaysRequested: validityDays,
       validityDaysApplied,

--- a/tests/certController.test.js
+++ b/tests/certController.test.js
@@ -17,6 +17,7 @@ const revocation = require('../src/resources/revocation');
 const controller = require('../src/controllers/certController');
 const config = require('../src/resources/config')();
 const crlService = require('../src/services/crlService');
+const service = require('../src/services/certService');
 
 describe('certController', () => {
   beforeEach(() => {
@@ -147,5 +148,13 @@ describe('certController', () => {
     const reqInstance = CertificateRequest.mock.results[0].value;
     expect(reqInstance.setCertType).toHaveBeenCalledWith('ldapServer');
     expect(reqInstance.addAltNames).toHaveBeenCalledWith(['alt.example.com']);
+  });
+
+  test('renewCertificate forwards to service', async() => {
+    const spy = jest.spyOn(service, 'renewCertificate').mockResolvedValue({ renewed: true });
+    const result = await controller.renewCertificate('1', 'pass', true, 'bundle', 15, 'actor');
+    expect(result).toEqual({ renewed: true });
+    expect(spy).toHaveBeenCalledWith('1', 'pass', true, 'bundle', 15, 'actor');
+    spy.mockRestore();
   });
 });

--- a/tests/certRouter.test.js
+++ b/tests/certRouter.test.js
@@ -4,6 +4,7 @@ const express = require('express');
 jest.mock('../src/controllers/certController', () => ({
   newWebServerCertificate: jest.fn(),
   newLdapServerCertificate: jest.fn(),
+  renewCertificate: jest.fn(),
   newIntermediateCA: jest.fn(),
   revokeCertificate: jest.fn(),
   getCRL: jest.fn(),
@@ -109,6 +110,55 @@ describe('certRouter', () => {
     const res = await request(app).post('/new').send({ hostname: 'foo.example.com', passphrase: 'p' });
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'Invalid server configuration for profile validity' });
+  });
+
+  test('post /renew forwards to controller', async() => {
+    controller.renewCertificate.mockResolvedValue({ renewed: true });
+    const res = await request(app).post('/renew').send({ serialNumber: '1', passphrase: 'p', bundleP12: true, password: 'pass', validityDays: 20 });
+    expect(res.body).toEqual({ renewed: true });
+    expect(controller.renewCertificate).toHaveBeenCalledWith('1', 'p', true, 'pass', 20, expect.any(String));
+  });
+
+  test('post /renew rejects missing body', async() => {
+    const res = await request(app).post('/renew');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid request body' });
+  });
+
+  test('post /renew rejects invalid body', async() => {
+    mockConfig.getValidator.mockReturnValueOnce({ validateSchema: jest.fn(() => false) });
+    const res = await request(app).post('/renew').send({ invalid: true });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid request body: schema validation failed' });
+  });
+
+  test('post /renew rejects non-object body', async() => {
+    const res = await request(app)
+      .post('/renew')
+      .set('Content-Type', 'application/json')
+      .send('"bad"');
+    expect(res.status).toBe(400);
+  });
+
+  test('post /renew rejects validityDays out of allowed range', async() => {
+    mockConfig.getValidityLimits.mockReturnValueOnce({ minDays: 10, maxDays: 20 });
+    const res = await request(app).post('/renew').send({ serialNumber: '1', passphrase: 'p', validityDays: 30 });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'validityDays must be between 10 and 20' });
+  });
+
+  test('post /renew returns 404 when controller reports missing serial', async() => {
+    controller.renewCertificate.mockResolvedValue({ error: 'Serial not found' });
+    const res = await request(app).post('/renew').send({ serialNumber: '9', passphrase: 'p' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Serial not found' });
+  });
+
+  test('post /renew returns 404 when controller reports revoked certificate', async() => {
+    controller.renewCertificate.mockResolvedValue({ error: 'Certificate is revoked' });
+    const res = await request(app).post('/renew').send({ serialNumber: '9', passphrase: 'p' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Certificate is revoked' });
   });
 
   test('invalid passphrase handled gracefully', async() => {

--- a/tests/certService.test.js
+++ b/tests/certService.test.js
@@ -1,5 +1,17 @@
 jest.mock('../src/resources/certificateRequest');
 jest.mock('../src/resources/ca');
+jest.mock('../src/resources/revocation');
+jest.mock('node-forge', () => {
+  const actual = jest.requireActual('node-forge');
+  return {
+    ...actual,
+    pki: {
+      ...actual.pki,
+      certificateFromPem: jest.fn(),
+      publicKeyToPem: jest.fn(),
+    },
+  };
+});
 jest.mock('crypto', () => {
   const actual = jest.requireActual('crypto');
   return {
@@ -11,17 +23,22 @@ jest.mock('crypto', () => {
 const path = require('path');
 const CertificateRequest = require('../src/resources/certificateRequest');
 const CA = require('../src/resources/ca');
+const revocation = require('../src/resources/revocation');
+const forge = require('node-forge');
 const service = require('../src/services/certService');
 
 describe('certService', () => {
   beforeEach(() => {
     CertificateRequest.mockClear();
     CA.mockClear();
+    revocation.getBySerial.mockReset();
+    revocation.add.mockReset();
     CertificateRequest.mockImplementation(() => ({
       addAltNames: jest.fn(),
       sign: jest.fn(),
       setCertType: jest.fn(),
       verify: jest.fn(() => true),
+      getCSR: jest.fn(() => 'csr'),
       getPrivateKey: jest.fn(() => 'priv'),
       getPkcs12Bundle: jest.fn(() => 'p12data'),
     }));
@@ -32,6 +49,8 @@ describe('certService', () => {
       getCACertificate: jest.fn(() => 'cacert'),
       updateLog: jest.fn(),
     }));
+    revocation.getBySerial.mockResolvedValue({ serialNumber: '1', hostname: 'foo.example.com', expiration: new Date().toISOString(), revoked: false });
+    revocation.add.mockResolvedValue();
   });
 
   test('newWebServerCertificate returns an error when CSR verification fails', async() => {
@@ -126,5 +145,107 @@ describe('certService', () => {
     const result = await svc.newLdapServerCertificate('ldap.example.com', 'pass');
     expect(result).toEqual({ error: 'Root CA may not issue leaf certs' });
     process.env.CONFIG_PATH = orig;
+  });
+
+  test('renewCertificate reissues with stored subject and SANs', async() => {
+    const fs = require('fs');
+    jest.spyOn(fs.promises, 'readFile').mockImplementation((file) => {
+      if (file.includes('.cert.crt')) {
+        return Promise.resolve('CERTDATA');
+      }
+      if (file.includes('.key.pem')) {
+        return Promise.resolve('PRIVATEKEY');
+      }
+      return Promise.resolve('');
+    });
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+    revocation.getBySerial.mockResolvedValue({ serialNumber: '10', hostname: 'foo.example.com', expiration: new Date().toISOString(), revoked: false });
+    const mockCert = {
+      subject: { getField: jest.fn(() => ({ value: 'foo.example.com' })) },
+      extensions: [
+        { name: 'subjectAltName', altNames: [{ type: 2, value: 'foo.example.com' }, { type: 7, ip: '127.0.0.1' }] },
+        { name: 'extKeyUsage', serverAuth: true },
+      ],
+      publicKey: 'pub',
+    };
+    forge.pki.certificateFromPem.mockReturnValue(mockCert);
+    forge.pki.publicKeyToPem.mockReturnValue('pubPEM');
+    CA.mockImplementationOnce(() => ({
+      unlockCA: jest.fn(),
+      signCSR: jest.fn(() => ({ certificate: 'renewedCert', serial: '20', expiration: new Date('2030-01-01'), validityDaysApplied: 20 })),
+      getCertChain: jest.fn(() => 'chain'),
+      getCACertificate: jest.fn(() => 'cacert'),
+      updateLog: jest.fn(),
+    }));
+    const result = await service.renewCertificate('10', 'pass', true, 'bundle', 20, 'actor');
+    expect(result).toEqual({
+      certificate: 'renewedCert',
+      privateKey: 'PRIVATEKEY',
+      hostname: 'foo.example.com',
+      chain: 'renewedCertchain',
+      p12: 'p12data',
+    });
+    expect(revocation.add).toHaveBeenCalledWith('20', 'foo.example.com', expect.any(String));
+    expect(CertificateRequest).toHaveBeenCalledWith('foo.example.com', expect.objectContaining({ privateKeyPEM: 'PRIVATEKEY', publicKey: 'pubPEM' }));
+    fs.promises.readFile.mockRestore();
+    fs.promises.writeFile.mockRestore();
+  });
+
+  test('renewCertificate returns error when serial is missing', async() => {
+    revocation.getBySerial.mockResolvedValueOnce(null);
+    const result = await service.renewCertificate('99', 'pass');
+    expect(result).toEqual({ error: 'Serial not found' });
+  });
+
+  test('renewCertificate returns error when certificate material is missing', async() => {
+    const fs = require('fs');
+    jest.spyOn(fs.promises, 'readFile').mockRejectedValue(new Error('missing'));
+    const result = await service.renewCertificate('1', 'pass');
+    expect(result).toEqual({ error: 'Original certificate material not found' });
+    fs.promises.readFile.mockRestore();
+  });
+
+  test('renewCertificate returns error when entry is revoked', async() => {
+    revocation.getBySerial.mockResolvedValueOnce({ serialNumber: '5', hostname: 'foo.example.com', revoked: true });
+    const result = await service.renewCertificate('5', 'pass');
+    expect(result).toEqual({ error: 'Certificate is revoked' });
+  });
+
+  test('renewCertificate enforces validity limits', async() => {
+    const result = await service.renewCertificate('1', 'pass', false, null, 500);
+    expect(result).toEqual({ error: 'validityDays must be between 1 and 397' });
+  });
+
+  test('renewCertificate applies profile default validity when provided', async() => {
+    const fs = require('fs');
+    jest.spyOn(fs.promises, 'readFile').mockImplementation((file) => {
+      if (file.includes('.cert.crt')) {
+        return Promise.resolve('CERTDATA');
+      }
+      if (file.includes('.key.pem')) {
+        return Promise.resolve('PRIVATEKEY');
+      }
+      return Promise.resolve('');
+    });
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+    forge.pki.certificateFromPem.mockReturnValue({
+      subject: { getField: jest.fn(() => ({ value: 'foo.example.com' })) },
+      extensions: [{ name: 'extKeyUsage', serverAuth: true }],
+      publicKey: 'pub',
+    });
+    forge.pki.publicKeyToPem.mockReturnValue('pubPEM');
+    const caInstance = {
+      unlockCA: jest.fn(),
+      signCSR: jest.fn(() => ({ certificate: 'renewed', serial: '30', expiration: new Date('2031-01-01'), validityDaysApplied: 15 })),
+      getCertChain: jest.fn(() => 'chain'),
+      getCACertificate: jest.fn(() => 'cacert'),
+      updateLog: jest.fn(),
+    };
+    CA.mockImplementationOnce(() => caInstance);
+    const result = await service.renewCertificate('10', 'pass');
+    expect(caInstance.signCSR).toHaveBeenCalledWith(expect.anything(), { validityDays: 90 });
+    expect(result.certificate).toBe('renewed');
+    fs.promises.readFile.mockRestore();
+    fs.promises.writeFile.mockRestore();
   });
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -72,7 +72,7 @@ describe('config resource', () => {
   test('getProfileValidity returns configured profile metadata or null', () => {
     const fs = require('fs');
     // Load the defaults.json and modify a copy to include profileMetadata
-    const defaultsPath = require('path').join(__dirname, '..', 'config', 'defaults.json');
+    const defaultsPath = require('path').join(__dirname, '..', 'config', 'defaults.example.json');
     const original = fs.readFileSync(defaultsPath, 'utf8');
     const parsed = JSON.parse(original);
     parsed.profileMetadata = { webServer: { validityDays: 90 } };

--- a/tests/preSetup.js
+++ b/tests/preSetup.js
@@ -9,3 +9,7 @@ if (!fs.existsSync(dest)) {
   contents.storeDirectory = './files_test';
   fs.writeFileSync(dest, `${JSON.stringify(contents, null, 2)}\n`);
 }
+const store = path.join(__dirname, '../files_test');
+if (!fs.existsSync(store)) {
+  fs.mkdirSync(store, { recursive: true });
+}

--- a/tests/revocationResource.test.js
+++ b/tests/revocationResource.test.js
@@ -77,4 +77,16 @@ describe('revocation resource', () => {
     expect(result.revoked).toBe(true);
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
   });
+
+  test('getBySerial returns matching entry', async() => {
+    const entry = { serialNumber: '42', hostname: 'host', expiration: 'exp', revoked: false };
+    fs.promises.readFile.mockResolvedValueOnce(JSON.stringify({ certs: [entry] }));
+    const result = await revocation.getBySerial('42');
+    expect(result).toEqual(entry);
+  });
+
+  test('getBySerial returns null when missing', async() => {
+    const result = await revocation.getBySerial('100');
+    expect(result).toBeNull();
+  });
 });

--- a/tests/validator.test.js
+++ b/tests/validator.test.js
@@ -25,5 +25,7 @@ describe('validator', () => {
     expect(validator.validateSchema('new', valid)).toBe(true);
     expect(validator.validateSchema('new', { hostname: 'x' })).toBe(false);
     expect(validator.validateSchema('ldap', valid)).toBe(true);
+    expect(validator.validateSchema('renew', { serialNumber: '123', passphrase: 'secret' })).toBe(true);
+    expect(validator.validateSchema('renew', { serialNumber: 'abc', passphrase: 'secret' })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add a /renew API route and schema validation so callers can reissue certificates by serial number
- implement renewal logic that reuses stored subject/SANs, honors validity policies, and records audit entries
- extend tests, setup helpers, and documentation to cover the renewal workflow and supporting utilities

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a244b6ac8327848f164919f32931)